### PR TITLE
Enable NSXv3 and DVS drivers to work together

### DIFF
--- a/networking_nsxv3/common/config.py
+++ b/networking_nsxv3/common/config.py
@@ -131,8 +131,32 @@ nsxv3_opts = [
     )
 ]
 
+vsphere_opts = [
+    cfg.StrOpt(
+        'vsphere_login_username',
+        default='administrator@vsphere.local',
+        help="vSphere client login user"
+    ),
+    cfg.StrOpt(
+        'vsphere_login_password',
+        default='VMware1!',
+        help="vSphere client login password."
+    ),
+    cfg.HostAddressOpt(
+        'vsphere_login_hostname',
+        default='vc-l-01a.corp.local',
+        help="vSphere client hostname or IP address."
+    ),
+    cfg.BoolOpt(
+        'vsphere_suppress_ssl_wornings',
+        default=True,
+        help="vSphere client disables ssl host validattion. [Development Mode]"
+    ),
+]
+
 
 cfg.CONF.register_opts(agent_opts, "AGENT")
 cfg.CONF.register_opts(agent_cli_opts, "AGENT_CLI")
 cfg.CONF.register_opts(nsxv3_opts, "NSXV3")
+cfg.CONF.register_opts(vsphere_opts, "vsphere")
 config.register_agent_state_opts_helper(cfg.CONF)

--- a/networking_nsxv3/common/constants.py
+++ b/networking_nsxv3/common/constants.py
@@ -16,6 +16,10 @@ NSXV3_SECURITY_GROUP_SCOPE = "security_group"
 NSXV3_SECURITY_GROUP_RULE_BATCH_SIZE = 265
 NSXV3_REVISION_SCOPE = "revision_number"
 
+NSXV3_MIGRATION_SCOPE = "vswitch_migration_target"
+NSXV3_MIGRATION_TAG_DVS = "dvs"
+NSXV3_MIGRATION_TAG_NVDS = "nvds"
+
 # Set RPC API version to 1.0 by default.
 # history
 #   1.1 Support Security Group RPC

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_client.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_client.py
@@ -253,6 +253,16 @@ class NSXv3ClientImpl(NSXv3Client):
         return None
 
     @connection_retry_policy(driver="sdk")
+    def list(self, sdk_service, **kwargs):
+        svc = sdk_service(self.stub_config)
+        svc_type = sdk_service.__class__
+
+        msg = "Getting objects from service='{}' ... by '{}' ".format(svc_type,
+                                                                      kwargs)
+        LOG.info(msg)
+        return svc.list(**kwargs)
+
+    @connection_retry_policy(driver="sdk")
     def get_by_attr(self, sdk_service, sdk_model, attr_key, attr_val):
         svc = sdk_service(self.stub_config)
         sdk_type = str(sdk_model.__class__.__name__)

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_migration.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_migration.py
@@ -1,0 +1,104 @@
+
+from oslo_log import log as logging
+
+from pyVmomi import vim
+from com.vmware.nsx.fabric_client import VirtualMachines
+from com.vmware.nsx_client import LogicalSwitches
+from com.vmware.nsx.model_client import LogicalSwitch
+
+from networking_nsxv3.common import constants as nsxv3_constants
+
+LOG = logging.getLogger(__name__)
+
+
+#     NSXv3 Agent annotations performing the migration from DVS to N-VDS
+
+# NSXv3 Scope/Tag flags organizing the migration flow from DVS to NVDS
+TAG_SCOPE = nsxv3_constants.NSXV3_MIGRATION_SCOPE
+TAG_DVS = nsxv3_constants.NSXV3_MIGRATION_TAG_DVS
+TAG_NVDS = nsxv3_constants.NSXV3_MIGRATION_TAG_NVDS
+
+
+class NSXv3NVDsMigrator(object):
+
+    def __init__(self, target, func, *args, **kwargs):
+        self.target = target
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+
+    def decorate(self):
+        if hasattr(self, self.func.__name__):
+            func = getattr(self, self.func.__name__)
+            return func(*self.args, **self.kwargs)
+        else:
+            return self.func(self.target, *self.args, **self.kwargs)
+
+    def _get_port_tags(self, port, scope):
+        result = []
+        msg_ambiguous = "Ambiguous. Found {} virtual machines with id={}"
+        device_id = port.get("device_id")
+        # Only ports with assocate devices could be target of migration
+        if not device_id:
+            return result
+        vms = self.target.nsxv3.list(VirtualMachines,
+                                     external_id=device_id).results
+        # Only ports with assocate devices could be target of migration
+        # Port device is not created yet
+        if len(vms) == 0:
+            return result
+        if len(vms) > 1:
+            raise Exception(msg_ambiguous.format(len(vms), device_id))
+        nsxv3_tags = vms.pop().tags
+        nsxv3_tags = nsxv3_tags if nsxv3_tags else []
+        for tag in nsxv3_tags:
+            if tag.scope == TAG_SCOPE:
+                result.append(tag.tag)
+        return result
+
+    def _migrate_port(self, port):
+        vsphere = self.target.vsphere
+        nsxv3 = self.target.nsxv3
+
+        vif_details = port.get("binding:vif_details")
+        nsx_ls_id = vif_details.get("nsx-logical-switch-id")
+
+        vim_vm = vsphere.get_managed_object(vim.VirtualMachine,
+                                            port.get("device_id"))
+        vim_nic = vsphere.get_vm_nic_by_mac(vm_obj=vim_vm,
+                                            macAddress=port.get("mac_address"))
+        nsx_ls_spec = LogicalSwitch(id=nsx_ls_id)
+        nsx_ls = nsxv3.get(sdk_service=LogicalSwitches, sdk_model=nsx_ls_spec)
+
+        vim_net = vsphere.get_managed_object(vim.Network, nsx_ls.display_name)
+        if not isinstance(vim_net, vim.OpaqueNetwork):
+            raise "Provided network '{}' is not of type NSX-T".format(vim_net)
+        vsphere.attach_vm_to_network(vm_obj=vim_vm, nic_obj=vim_nic,
+                                     network_obj=vim_net)
+
+    # Agent RCP method signature
+    def get_network_bridge(self, context, current, network_segments,
+                           network_current):
+        if TAG_DVS in self._get_port_tags(port=current, scope=TAG_SCOPE):
+            # Report unable to bind port as it is still managed by DVS
+            return {}
+        return self.func(self.target, *self.args, **self.kwargs)
+
+    # Agent RCP method signature
+    def port_update(self, context, port=None, network_type=None,
+                    physical_network=None, segmentation_id=None):
+        tags = self._get_port_tags(port=port, scope=TAG_SCOPE)
+        if TAG_DVS in tags:
+            # Skip port update as port is still managed by DVS
+            return
+        if TAG_NVDS in tags:
+            # Migrate port from DVS to NVDS
+            self._migrate_port(port)
+        return self.func(self.target, *self.args, **self.kwargs)
+
+
+class migrator(object):
+    def __call__(self, func):
+        def decorator(self, *args, **kwargs):
+            return NSXv3NVDsMigrator(self, func, *args, **kwargs).decorate()
+        return decorator

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/vsphere_client.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/vsphere_client.py
@@ -1,0 +1,98 @@
+import ssl
+from pyVmomi import vmodl, vim
+from pyVim.connect import SmartConnect
+
+from oslo_config import cfg
+from oslo_log import log as logging
+
+
+LOG = logging.getLogger(__name__)
+
+
+# TODO - add connection retry annotations
+class VSphereClient(object):
+
+    def _login(self):
+        suppress_ssl_wornings = cfg.CONF.vsphere.vsphere_suppress_ssl_wornings
+        hostname = cfg.CONF.vsphere.vsphere_login_hostname
+        username = cfg.CONF.vsphere.vsphere_login_username
+        password = cfg.CONF.vsphere.vsphere_login_password
+
+        ssl_context = None
+        if suppress_ssl_wornings:
+            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+            ssl_context.verify_mode = ssl.CERT_NONE
+        self.connection = SmartConnect(host=hostname, user=username,
+                                       pwd=password, sslContext=ssl_context)
+
+    def _get_conn(self):
+        if self.connection:
+            return self.connection
+        else:
+            raise "VSphere client have to be connected first."
+
+    def get_managed_object(self, vimtype, name):
+        content = self._get_conn().content
+        ccv = content.viewManager.CreateContainerView
+        for o in ccv(content.rootFolder, [vimtype], True).view:
+            if name in o.name:
+                return o
+
+    def wait_for_task(self, task):
+        pc = self._get_conn().content.propertyCollector
+        pc_spec = vmodl.query.PropertyCollector
+
+        obj_specs = [pc_spec.ObjectSpec(obj=task)]
+        property_spec = pc_spec.PropertySpec(type=vim.Task,
+                                             pathSet=[], all=True)
+
+        filter_spec = pc_spec.FilterSpec(objectSet=obj_specs,
+                                         propSet=[property_spec])
+
+        pcfilter = pc.CreateFilter(filter_spec, True)
+        try:
+            obj_set = pc.WaitForUpdates().filterSet[0].objectSet[0]
+            task = obj_set.obj
+            for change in obj_set.changeSet:
+                if change.name == 'info':
+                    state = change.val.state
+                elif change.name == 'info.state':
+                    state = change.val
+                else:
+                    continue
+
+                if state == vim.TaskInfo.State.error:
+                    raise task.info.error
+            return task
+        finally:
+            if pcfilter:
+                pcfilter.Destroy()
+
+    def attach_vm_to_network(self, vm_obj, nic_obj, network_obj):
+        nic_spec = vim.vm.device.VirtualDeviceSpec()
+        nic_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+        nic_spec.device = nic_obj
+        nic_spec.device.key = nic_obj.key
+        nic_spec.device.macAddress = nic_obj.macAddress
+        nic_spec.device.backing = nic_obj.backing
+        nic_spec.device.wakeOnLanEnabled = nic_obj.wakeOnLanEnabled
+        nic_spec.device.connectable = nic_obj.connectable
+
+        nic_spec.device.backing = vim.vm.device.VirtualEthernetCard\
+            .OpaqueNetworkBackingInfo()
+        network_id = network_obj.summary.opaqueNetworkId
+        network_type = network_obj.summary.opaqueNetworkType
+        nic_spec.device.backing.opaqueNetworkType = network_type
+        nic_spec.device.backing.opaqueNetworkId = network_id
+
+        spec = vim.vm.ConfigSpec(deviceChange=[nic_spec])
+        task = vm_obj.ReconfigVM_Task(spec=spec)
+        self.wait_for_task(task)
+        LOG.info("Server with id={}, nic_mac={} was attached to network={}."
+                 .format(vm_obj.name, nic_obj.macAddress, network_obj.name))
+
+    def get_vm_nic_by_mac(self, vm_obj, macAddress):
+        card = vim.vm.device.VirtualEthernetCard
+        for device in vm_obj.config.hardware.device:
+            if isinstance(device, card) and device.macAddress == macAddress:
+                return device


### PR DESCRIPTION
The driver supports migration of worklods from DVS ML2 driver to NSXv3 ML2 driver.

Migration Prerequisites

- ESXi hosts have to be both enabled for DVS and N-VDS workloads
- Virtual machines target of migration have to be assigned with the NSX-T tag:
        scope = "vswitch_migration_target"
        tag = "dvs"

- Enable DVS and NSX-T drivers to work at the same time as follow:
        # /etc/neutron/plugins/ml2/ml2_conf.ini
        mechanism_drivers = nsxv3,dvs

NSX-T ML2 Driver Behaviour

- Once both drivers are enabled the OpenStack networking will behave as follow:
    - network operations related to the existing virtual machines assigned with NSX-T tag = "dvs" will be skipped by NSX-T driver and handled by the DVS driver
    - network operations related to the new virtual machines will be handled by the NSX-T dirver
- Migrate DVS managed virtual machine to NSX-T:
    - change the NSX-T tag:
            scope = "vswitch_migration_target"
            tag = "nvds"
    - re-trigger port binding for every virtual machine port by using an random name for a dummy host and then switch back to the original host
            os port set --host <dummy host> <port_id>
            os port set --host <original host> <port_id>