### PR TITLE
Add port protection configuration switch

### DIFF
--- a/networking_nsxv3/common/config.py
+++ b/networking_nsxv3/common/config.py
@@ -115,6 +115,11 @@ nsxv3_opts = [
         help="NSXv3 Manager transport zone name."
     ),
     cfg.BoolOpt(
+        'nsxv3_enable_spoof_guard',
+        default=False,
+        help="NSXv3 Manager enables SpoofGuard protection."
+    ),
+    cfg.BoolOpt(
         'nsxv3_suppress_ssl_wornings',
         default=True,
         help="NSXv3 Manager disables ssl host validattion. [Development Mode]"

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_facada.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_facada.py
@@ -103,12 +103,19 @@ class NSXv3Facada(nsxv3_client.NSXv3ClientImpl):
 
         ipd_sp = self.create(sdk_service=SwitchingProfiles,
                              sdk_model=ipd_sp_spec)
+
         sg_sp = self.create(sdk_service=SwitchingProfiles,
                             sdk_model=sg_sp_spec)
-        self.default_switching_profile_ids = [
-            SwitchingProfileTypeIdEntry(key=self.IPK, value=ipd_sp.id),
-            SwitchingProfileTypeIdEntry(key=self.SGK, value=sg_sp.id)
+
+        id_entities = [
+            SwitchingProfileTypeIdEntry(key=self.IPK, value=ipd_sp.id)
         ]
+
+        if cfg.CONF.NSXV3.nsxv3_enable_spoof_guard:
+            id_entities.append(SwitchingProfileTypeIdEntry(key=self.SGK,
+                                                           value=sg_sp.id))
+
+        self.default_switching_profile_ids = id_entities
 
     def get_switch_id_for_segmentation_id(self, segmentation_id):
         sw_name = "{}-{}".format(self.tz_name, segmentation_id)

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_migration.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_migration.py
@@ -67,6 +67,8 @@ class NSXv3NVDsMigrator(object):
                                             port.get("device_id"))
         vim_nic = vsphere.get_vm_nic_by_mac(vm_obj=vim_vm,
                                             macAddress=port.get("mac_address"))
+        # Change NIC external ID to the OpenStack Port
+        vim_nic.key = port.get("id")
         nsx_ls_spec = LogicalSwitch(id=nsx_ls_id)
         nsx_ls = nsxv3.get(sdk_service=LogicalSwitches, sdk_model=nsx_ls_spec)
 

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_migration.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_migration.py
@@ -1,5 +1,6 @@
 
 from oslo_log import log as logging
+from oslo_config import cfg
 
 from pyVmomi import vim
 from com.vmware.nsx.fabric_client import VirtualMachines
@@ -7,6 +8,8 @@ from com.vmware.nsx_client import LogicalSwitches
 from com.vmware.nsx.model_client import LogicalSwitch
 
 from networking_nsxv3.common import constants as nsxv3_constants
+from networking_nsxv3.common.locking import LockManager
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import nsxv3_agent
 
 LOG = logging.getLogger(__name__)
 
@@ -56,9 +59,18 @@ class NSXv3NVDsMigrator(object):
                 result.append(tag.tag)
         return result
 
-    def _migrate_port(self, port):
+    def _migrate_port(self, port, segmentation_id):
         vsphere = self.target.vsphere
         nsxv3 = self.target.nsxv3
+
+        if not cfg.CONF.host == port['binding:host_id']:
+            LOG.debug("Skipping Port='{}' as it is not managed by the agent",
+                      str(port))
+            return
+
+        lock_id = nsxv3_agent.get_segmentation_id_lock(segmentation_id)
+        with LockManager.get_lock(lock_id):
+            nsxv3.get_switch_id_for_segmentation_id(segmentation_id)
 
         vif_details = port.get("binding:vif_details")
         nsx_ls_id = vif_details.get("nsx-logical-switch-id")
@@ -74,28 +86,14 @@ class NSXv3NVDsMigrator(object):
 
         vim_net = vsphere.get_managed_object(vim.Network, nsx_ls.display_name)
         if not isinstance(vim_net, vim.OpaqueNetwork):
-            raise "Provided network '{}' is not of type NSX-T".format(vim_net)
+            raise Exception("Provided network '{}' is not of type NSX-T".format(vim_net))
         vsphere.attach_vm_to_network(vm_obj=vim_vm, nic_obj=vim_nic,
                                      network_obj=vim_net)
 
     # Agent RCP method signature
-    def get_network_bridge(self, context, current, network_segments,
-                           network_current):
-        if TAG_DVS in self._get_port_tags(port=current, scope=TAG_SCOPE):
-            # Report unable to bind port as it is still managed by DVS
-            return {}
-        return self.func(self.target, *self.args, **self.kwargs)
-
-    # Agent RCP method signature
     def port_update(self, context, port=None, network_type=None,
                     physical_network=None, segmentation_id=None):
-        tags = self._get_port_tags(port=port, scope=TAG_SCOPE)
-        if TAG_DVS in tags:
-            # Skip port update as port is still managed by DVS
-            return
-        if TAG_NVDS in tags:
-            # Migrate port from DVS to NVDS
-            self._migrate_port(port)
+        self._migrate_port(port, segmentation_id)
         return self.func(self.target, *self.args, **self.kwargs)
 
 

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_migration.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_migration.py
@@ -68,7 +68,7 @@ class NSXv3NVDsMigrator(object):
         vim_nic = vsphere.get_vm_nic_by_mac(vm_obj=vim_vm,
                                             macAddress=port.get("mac_address"))
         # Change NIC external ID to the OpenStack Port
-        vim_nic.key = port.get("id")
+        vim_nic.externalId = port.get("id")
         nsx_ls_spec = LogicalSwitch(id=nsx_ls_id)
         nsx_ls = nsxv3.get(sdk_service=LogicalSwitches, sdk_model=nsx_ls_spec)
 

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/vsphere_client.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/vsphere_client.py
@@ -73,6 +73,7 @@ class VSphereClient(object):
         nic_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
         nic_spec.device = nic_obj
         nic_spec.device.key = nic_obj.key
+        nic_spec.device.externalId = nic_obj.externalId
         nic_spec.device.macAddress = nic_obj.macAddress
         nic_spec.device.backing = nic_obj.backing
         nic_spec.device.wakeOnLanEnabled = nic_obj.wakeOnLanEnabled


### PR DESCRIPTION
- NSXv3 Agent can be configured whether to use SpoofGuard or not
- SpoofGuard is disabled by default - this is required due to the fact
that NSX-T does not implement CIDR manual address port binding as
OpenStack

- Need further investigation on how SpoofGuard will support CIDRs as
manual bindings