### PR TITLE
Improve synchronization between OpenStack and NSX-T

### DIFF
--- a/networking_nsxv3/api/rpc.py
+++ b/networking_nsxv3/api/rpc.py
@@ -105,7 +105,7 @@ class NSXv3ServerRpcApi(object):
     changing rpc interfaces, see doc/source/contributor/internals/rpc_api.rst.
     """
 
-    rpc_version=nsxv3_constants.NSXV3_SERVER_RPC_VERSION
+    rpc_version = nsxv3_constants.NSXV3_SERVER_RPC_VERSION
 
     _LIMIT = 100
     _CREATE_AFTER = datetime.utcfromtimestamp(0).isoformat()
@@ -121,8 +121,12 @@ class NSXv3ServerRpcApi(object):
     def get_port_revision_tuples(
             self, limit=_LIMIT, created_after=_CREATE_AFTER):
         cctxt = self.client.prepare()
-        return cctxt.call(self.context, 'get_port_revision_tuples', host=self.host,
-                          limit=limit, created_after=created_after)
+        return cctxt.call(
+            self.context,
+            'get_port_revision_tuples',
+            host=self.host,
+            limit=limit,
+            created_after=created_after)
 
     @log_helpers.log_method_call
     def get_qos_policy_revision_tuples(
@@ -134,14 +138,14 @@ class NSXv3ServerRpcApi(object):
     @log_helpers.log_method_call
     def get_security_group_revision(self, security_group_id):
         cctxt = self.client.prepare()
-        return cctxt.call(self.context, 'get_security_group_revision', 
+        return cctxt.call(self.context, 'get_security_group_revision',
                           security_group_id=security_group_id)
 
     @log_helpers.log_method_call
     def get_security_group_revision_tuples(
-        self, limit=_LIMIT, created_after=_CREATE_AFTER):
+            self, limit=_LIMIT, created_after=_CREATE_AFTER):
         cctxt = self.client.prepare()
-        return cctxt.call(self.context, 'get_security_group_revision_tuples', 
+        return cctxt.call(self.context, 'get_security_group_revision_tuples',
                           limit=limit, created_after=created_after)
 
     @log_helpers.log_method_call
@@ -196,8 +200,8 @@ class NSXv3ServerRpcApi(object):
     def get_security_group_members_address_bindings_ips(self,
                                                         security_group_id):
         cctxt = self.client.prepare()
-        return cctxt.call(self.context, 
-                          'get_security_group_members_address_bindings_ips', 
+        return cctxt.call(self.context,
+                          'get_security_group_members_address_bindings_ips',
                           security_group_id=security_group_id)
 
 
@@ -276,4 +280,3 @@ class NSXv3ServerRpcCallback(object):
                                                         security_group_id):
         return db.get_security_group_members_address_bindings_ips(
             context, security_group_id)
-

--- a/networking_nsxv3/common/config.py
+++ b/networking_nsxv3/common/config.py
@@ -27,6 +27,11 @@ agent_opts = [
         help='''Objects per second synchronizing OpenStack and NSXv3.'''
     ),
     cfg.IntOpt(
+        'sync_full_schedule',
+        default=24,
+        help='''Full-sync schedule in hours between OpenStack and NSXv3.'''
+    ),
+    cfg.IntOpt(
         'locking_coordinator_url',
         default=None,
         help='Url of the distributed locking coordinator. None for local.'

--- a/networking_nsxv3/db/db.py
+++ b/networking_nsxv3/db/db.py
@@ -24,6 +24,7 @@ def _validate_one(result, error):
     else:
         raise Exception(msg.format(error))
 
+
 def _get_datetime(datetime_value):
     if isinstance(datetime_value, datetime):
         return datetime_value
@@ -32,6 +33,7 @@ def _get_datetime(datetime_value):
     else:
         raise Exception(
             "datetime_value object should be datetime or string in isoformat")
+
 
 def get_port_revision_tuples(
         context,
@@ -55,6 +57,7 @@ def get_port_revision_tuples(
         limit
     ).all()
 
+
 def get_qos_policy_revision_tuples(
         context,
         limit,
@@ -73,6 +76,7 @@ def get_qos_policy_revision_tuples(
         limit
     ).all()
 
+
 def get_security_group_revision(context, security_group_id):
     result = context.session.query(
         sg_db.SecurityGroup.id,
@@ -84,6 +88,7 @@ def get_security_group_revision(context, security_group_id):
     ).one_or_none()
     return _validate_one(result,
                          "Security Group ID='{}'".format(security_group_id))
+
 
 def get_security_group_revision_tuples(
         context,
@@ -103,6 +108,7 @@ def get_security_group_revision_tuples(
         limit
     ).all()
 
+
 def get_qos(context, qos_id):
     result = context.session.query(
         QosPolicy.name,
@@ -115,6 +121,7 @@ def get_qos(context, qos_id):
     return _validate_one(result,
                          "QoS Policy ID='{}'".format(qos_id))
 
+
 def get_qos_bwl_rules(context, qos_id):
     return context.session.query(
         QosBandwidthLimitRule.direction,
@@ -124,6 +131,7 @@ def get_qos_bwl_rules(context, qos_id):
         QosBandwidthLimitRule.qos_policy_id == qos_id
     ).all()
 
+
 def get_qos_dscp_rules(context, qos_id):
     return context.session.query(
         QosDscpMarkingRule.qos_policy_id,
@@ -131,6 +139,7 @@ def get_qos_dscp_rules(context, qos_id):
     ).filter(
         QosDscpMarkingRule.qos_policy_id == qos_id
     ).all()
+
 
 def get_port(context, port_id):
     result = context.session.query(
@@ -154,12 +163,14 @@ def get_port(context, port_id):
     return _validate_one(result,
                          "Port ID='{}'".format(port_id))
 
+
 def get_port_security_groups(context, port_id):
     return context.session.query(
         sg_db.SecurityGroupPortBinding.security_group_id
     ).filter(
         sg_db.SecurityGroupPortBinding.port_id == port_id
     ).all()
+
 
 def get_port_allowed_pairs(context, port_id):
     return context.session.query(
@@ -169,6 +180,7 @@ def get_port_allowed_pairs(context, port_id):
         allowed_address_pair.AllowedAddressPair.port_id == port_id
     ).all()
 
+
 def get_port_addresses(context, port_id):
     return context.session.query(
         IPAllocation.ip_address,
@@ -176,6 +188,7 @@ def get_port_addresses(context, port_id):
     ).filter(
         IPAllocation.port_id == port_id
     ).all()
+
 
 def _query_securitygrouprules(context, ids):
     return context.session.query(
@@ -194,6 +207,7 @@ def _query_securitygrouprules(context, ids):
         sg_db.SecurityGroupRule.id in ids
     ).all()
 
+
 def _query_standardattributes(context, created_at):
     return context.session.query(
         StandardAttribute.id,
@@ -205,6 +219,7 @@ def _query_standardattributes(context, created_at):
     ).filter(
         StandardAttribute.created_at >= created_at
     ).all()
+
 
 def _get_latest_changes(context, resource_type, updated_at):
     return context.session.query(
@@ -234,6 +249,7 @@ def _get_latest_changes(context, resource_type, updated_at):
         StandardAttribute.resource_type == resource_type
     ).all()
 
+
 def get_rules_for_security_groups_id(context, security_group_id):
     return context.session.query(
         sg_db.SecurityGroupRule
@@ -241,12 +257,14 @@ def get_rules_for_security_groups_id(context, security_group_id):
         sg_db.SecurityGroupRule.security_group_id == security_group_id
     ).all()
 
+
 def _get_port_id_by_sec_group_id(context, sec_group_id):
     return context.session.query(
         sg_db.SecurityGroupPortBinding.port_id
     ).filter(
         sg_db.SecurityGroupPortBinding.security_group_id == sec_group_id
     ).all()
+
 
 def get_security_group_members_ips(context, security_group_id):
     port_id = sg_db.SecurityGroupPortBinding.port_id
@@ -261,8 +279,9 @@ def get_security_group_members_ips(context, security_group_id):
             security_group_id == group_id
         ).all())
 
-def get_security_group_members_address_bindings_ips(context, 
-                                                     security_group_id):
+
+def get_security_group_members_address_bindings_ips(context,
+                                                    security_group_id):
     port_id = sg_db.SecurityGroupPortBinding.port_id
     group_id = sg_db.SecurityGroupPortBinding.security_group_id
     return list(

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_agent.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_agent.py
@@ -5,10 +5,12 @@ import sys
 
 import netaddr
 import oslo_messaging
+from com.vmware.nsx_client import TransportZones
 from com.vmware.nsx.model_client import (FirewallRule,
                                          IPSet,
                                          LogicalPort,
-                                         QosSwitchingProfile)
+                                         QosSwitchingProfile,
+                                         TransportZone)
 from neutron.common import config as common_config
 from neutron.common import profiler, topics
 from neutron.plugins.ml2.drivers.agent import _agent_manager_base as amb
@@ -69,14 +71,12 @@ class NSXv3AgentManagerRpcSecurityGroupCallBackMixin(object):
         with LockManager.get_lock(sg_id):
             (ipset, nsg, sec) = self.nsxv3.get_or_create_security_group(sg_id)
 
-            get_dict = self.nsxv3.get_name_revision_dict
+            _, revs_ips, _ = self.nsxv3.get_revisions(IPSet())
+            _, revs_fwr, meta_fwr = self.nsxv3.get_revisions(
+                FirewallRule(),
+                attr_key="section_id",
+                attr_val=sec.id)
 
-            (_, ips_name_id) = get_dict(IPSet())
-            (_, rul_name_id) = get_dict(FirewallRule(),
-                                        attr_key="section_id",
-                                        attr_val=sec.id)
-
-            nsx_rules = rul_name_id
             neutron_rules = self.rpc.get_rules_for_security_groups_id(sg_id)
 
             attrs = ["id", "port_range_min", "port_range_max", "protocol",
@@ -94,17 +94,19 @@ class NSXv3AgentManagerRpcSecurityGroupCallBackMixin(object):
 
                 fwr["local_group_id"] = ipset.id
                 fwr["apply_to"] = nsg.id
-                if remote_group_id in ips_name_id:
-                    fwr["remote_group_id"] = ips_name_id[remote_group_id]
+                if remote_group_id in revs_ips:
+                    fwr["remote_group_id"] = revs_ips[remote_group_id]
 
-                if name in nsx_rules:
-                    del nsx_rules[name]
-                    continue
+                if name in revs_fwr:
+                    # If the rule is disabled recreate it
+                    if not meta_fwr.get(name).get("FirewallRule.disabled"):
+                        del revs_fwr[name]
+                        continue
 
-                fwr = self.nsxv3.get_security_group_rule_spec(fwr)
-                if fwr:
-                    add_rules.append(fwr)
-            del_rules = nsx_rules.values()
+                fwr_spec = self.nsxv3.get_security_group_rule_spec(fwr)
+                if fwr_spec:
+                    add_rules.append(fwr_spec)
+            del_rules = revs_fwr.values()
 
             (sg_id, revision) = self.rpc.get_security_group_revision(sg_id)
 
@@ -121,14 +123,14 @@ class NSXv3AgentManagerRpcSecurityGroupCallBackMixin(object):
     # RPC method
     def security_groups_member_updated(self, context, **kwargs):
         o = kwargs["security_groups"]
-        o = o if type(o) == list else [o]
+        o = o if isinstance(o, list) else [o]
         for id in o:
             self.security_group_member_updated(id)
 
     # RPC method
     def security_groups_rule_updated(self, context, **kwargs):
         o = kwargs["security_groups"]
-        o = o if type(o) == list else [o]
+        o = o if isinstance(o, list) else [o]
         for id in o:
             self.security_group_rule_updated(id)
 
@@ -161,78 +163,116 @@ class NSXv3AgentManagerRpcCallBackBase(
                      .format(self.pool_workers.running()))
 
     def _sync_all(self):
+        rate = cfg.CONF.AGENT.sync_requests_per_second
+
+        LFS_TAG = "last_full_synchronization"
+        msg = "SYNCHRONIZATION CYCLE - {}"
+
+        def get_date(timestamp=None):
+            DATETIME_FORMATTER = "%Y-%m-%d %H:%M:%S"
+            if timestamp is None:
+                return datetime.datetime.now().strftime(DATETIME_FORMATTER)
+            else:
+                return datetime.datetime.strptime(
+                    timestamp, DATETIME_FORMATTER)
+
+        @Scheduler(rate=rate, limit=1)
+        def spawn(func, *args, **kw):
+            self.pool_workers.spawn_n(func, *args, **kw)
+
+        query_sg = self.rpc.get_security_group_revision_tuples
+        query_qos = self.rpc.get_qos_policy_revision_tuples
+        query_port = self.rpc.get_port_revision_tuples
+
         with LockManager.get_lock(AGENT_SYNCHRONIZATION_LOCK):
-            msg = "FULL SYNCHRONIZATION CYCLE - {}"
-            rate = cfg.CONF.AGENT.sync_requests_per_second
-
-            @Scheduler(rate=rate, limit=1)
-            def spawn(func, *args, **kw):
-                self.pool_workers.spawn_n(func, *args, **kw)
-
             LOG.info(msg.format("STARTED"))
 
-            (added, updated, orphaned) = self.get_sync_data(
-                sdk_model=IPSet(),
-                query=self.rpc.get_security_group_revision_tuples)
-            # Create all Security Groups before use their references in rules
-            # Creating FirewallSections, IPSets, NSGroups without FirewallRules
-            for oid in added:
-                spawn(self.sync_security_group, oid, update_rules=False)
-            self.pool_workers.waitall()
+            delta = datetime.timedelta(hours=cfg.CONF.AGENT.sync_full_schedule)
 
-            # Creating all FirewallRules and update Revisions
-            for oid in added:
-                spawn(self.sync_security_group, oid)
-            for oid in updated:
-                spawn(self.sync_security_group, oid)
-            for oid in orphaned:
-                if nsxv3_utils.is_valid_uuid(oid):
-                    spawn(self.sync_security_group_orphaned, oid)
+            sdk_service = TransportZones
+            sdk_model = TransportZone(display_name=self.nsxv3.tz_name)
 
-            (added, updated, orphaned) = self.get_sync_data(
-                sdk_model=QosSwitchingProfile(),
-                query=self.rpc.get_qos_policy_revision_tuples)
-            for oid in added:
-                spawn(self.sync_qos, oid)
-            for oid in updated:
-                spawn(self.sync_qos, oid)
+            tags = self.nsxv3.get_tags(sdk_service, sdk_model)
+            timestamp = tags.get(LFS_TAG)
 
-            (added, updated, orphaned) = self.get_sync_data(
-                sdk_model=LogicalPort(),
-                query=self.rpc.get_port_revision_tuples)
-            for oid in updated:
-                spawn(self.sync_port, oid)
+            # TODO - implement configuration
 
-        self.pool_workers.waitall()
-        LOG.info(msg.format("COMPLETED"))
-
-    def get_sync_delta(self, neutron_dict, nsxv3_dict):
-        orphaned = nsxv3_dict.copy()
-        added = {}
-        updated = {}
-
-        # OpenStack is single source of truth
-        for id in neutron_dict:
-            if id in orphaned:
-                ep_revision = orphaned.pop(id)
-                if neutron_dict[id] != ep_revision:
-                    updated[id] = neutron_dict[id]
+            if timestamp and get_date(timestamp) + \
+                    delta > datetime.datetime.now():
+                self._sync_security_groups(spawn)
+                self._sync_qoses(spawn)
+                self._sync_ports(spawn)
             else:
-                added[id] = neutron_dict[id]
-        return (added, updated, orphaned)
+                for oid in self.get_revisions(
+                        query=query_sg).keys():
+                    spawn(self.sync_security_group, oid)
+                for oid in self.get_revisions(
+                        query=query_qos).keys():
+                    spawn(self.sync_qos, oid)
+                for oid in self.get_revisions(
+                        query=query_port).keys():
+                    spawn(self.sync_port, oid)
+                tags[LFS_TAG] = get_date()
+                self.nsxv3.set_tags(sdk_service, sdk_model, tags)
 
-    def get_sync_data(self, sdk_model, query):
-        sdk_type = sdk_model.__class__.__name__
-        neutron_dict = self.get_name_revision_dict(query=query)
-        (name_revision, _) = self.nsxv3.get_name_revision_dict(
-            sdk_model=sdk_model)
+            self.pool_workers.waitall()
+            LOG.info(msg.format("COMPLETED"))
 
-        (added, updated, orphaned) = self.get_sync_delta(
-            neutron_dict=neutron_dict, nsxv3_dict=name_revision)
-        LOG.info("Neutron -> NSX create {}={}".format(sdk_type, added))
-        LOG.info("Neutron -> NSX update {}={}".format(sdk_type, updated))
-        LOG.info("Neutron -> NSX orphan {}={}".format(sdk_type, orphaned))
-        return (added, updated, orphaned)
+    def _sync_report(self, object_name, outdated, orphaned):
+        report = dict()
+        report["outdated"] = outdated
+        report["orphaned"] = orphaned
+        LOG.info("Synchronizing {} {}".format(object_name, report))
+
+    def _sync_get_content(self, sdk_model, os_query):
+        revs_os = self.get_revisions(query=os_query)
+        revs_nsx, _, _ = self.nsxv3.get_revisions(sdk_model=sdk_model)
+
+        outdated = set()
+
+        for key, rev in revs_os.items():
+            if revs_nsx.get(key) != rev:
+                outdated.add(key)
+
+        orphaned = set(revs_nsx.keys()).difference(revs_os.keys())
+        return outdated, orphaned
+
+    def _sync_security_groups(self, spawn):
+        outdated, orphaned = self._sync_get_content(
+            sdk_model=IPSet(),
+            os_query=self.rpc.get_security_group_revision_tuples)
+
+        # Create all Security Groups before use their references in rules
+        # Creating FirewallSections, IPSets, NSGroups without FirewallRules
+        for oid in outdated:
+            spawn(self.sync_security_group, oid, update_rules=False)
+        self.pool_workers.waitall()
+
+        for oid in outdated:
+            spawn(self.sync_security_group, oid)
+        for oid in orphaned:
+            if nsxv3_utils.is_valid_uuid(oid):
+                spawn(self.sync_security_group_orphaned, oid)
+
+        self._sync_report("Security Groups", outdated, orphaned)
+
+    def _sync_qoses(self, spawn):
+        outdated, orphaned = self._sync_get_content(
+            sdk_model=QosSwitchingProfile(),
+            os_query=self.rpc.get_qos_policy_revision_tuples)
+
+        for oid in outdated:
+            spawn(self.sync_qos, oid)
+        self._sync_report("QoS Profiles", outdated, orphaned)
+
+    def _sync_ports(self, spawn):
+        outdated, orphaned = self._sync_get_content(
+            sdk_model=LogicalPort(),
+            os_query=self.rpc.get_port_revision_tuples)
+
+        for oid in outdated:
+            spawn(self.sync_port, oid)
+        self._sync_report("Ports", outdated, orphaned)
 
     def sync_port(self, port_id):
         LOG.debug("Synching port '{}'.".format(port_id))
@@ -308,6 +348,14 @@ class NSXv3AgentManagerRpcCallBackBase(
         # except Exception as e:
         #     LOG.error("Unable to update policy '{}'".format(e))
 
+    def sync_qos_orphaned(self, qos_id):
+        LOG.debug("Removing orphaned QoS Policy '{}'.".format(qos_id))
+        policy = {
+            "id": qos_id,
+            "name": "ORPHANED-" + qos_id
+        }
+        self.delete_policy(context=None, policy=policy)
+
     def sync_security_group(self, security_group_id, update_rules=True):
         LOG.debug("Synching security group '{}'.".format(security_group_id))
         self.security_group_member_updated(security_group_id)
@@ -315,21 +363,22 @@ class NSXv3AgentManagerRpcCallBackBase(
             self.security_group_rule_updated(security_group_id)
 
     def sync_security_group_orphaned(self, security_group_id):
-        LOG.debug("Synching security group '{}'.".format(security_group_id))
+        LOG.debug("Removing orphaned security group '{}'.".format(
+            security_group_id))
         self.security_group_delete(security_group_id)
 
-    def get_name_revision_dict(self, query):
+    def get_revisions(self, query):
         limit = cfg.CONF.AGENT.rpc_max_records_per_query
-        id_rev = {}
+        rev = {}
         created_after = datetime.datetime(1970, 1, 1)
         while True:
             pr_tuples = query(limit=limit, created_after=created_after)
             for port, revision, _ in pr_tuples:
-                id_rev[port] = str(revision)
+                rev[port] = str(revision)
             if len(pr_tuples) < limit:
                 break
             created_after = pr_tuples.pop()[2]
-        return id_rev
+        return rev
 
     def get_network_bridge(
             self,
@@ -412,7 +461,8 @@ class NSXv3AgentManagerRpcCallBackBase(
     def delete_policy(self, context, policy):
         LOG.debug("Deleting policy={}.".format(policy["name"]))
         with LockManager.get_lock(policy["id"]):
-            self.nsxv3.delete_switch_profile_qos(self, policy["id"])
+            pass
+            # TODO self.nsxv3.delete_switch_profile_qos(policy["id"])
 
     def validate_policy(self, context, policy):
         LOG.debug("Validating policy={}.".format(policy["name"]))
@@ -428,9 +478,8 @@ class NSXv3Manager(amb.CommonAgentManagerBase):
         self.nsxv3 = nsxv3
         self.vsphere = vsphere
         self.rpc = None
-        self.rpc_plugin = nsxv3_rpc.NSXv3ServerRpcApi(context,
-                                                      nsxv3_constants.NSXV3_SERVER_RPC_TOPIC,
-                                                      cfg.CONF.host)
+        self.rpc_plugin = nsxv3_rpc.NSXv3ServerRpcApi(
+            context, nsxv3_constants.NSXV3_SERVER_RPC_TOPIC, cfg.CONF.host)
 
     def get_all_devices(self):
         """Get a list of all devices of the managed type from this host

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/driver.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/driver.py
@@ -9,7 +9,6 @@ from neutron_lib import context
 from neutron_lib.api.definitions import portbindings
 from neutron_lib.plugins.ml2 import api
 
-from neutron.common import topics
 from neutron.common import rpc
 
 
@@ -63,7 +62,7 @@ class VMwareNSXv3MechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
 
         conn = rpc.create_connection()
         conn.create_consumer(nsxv3_constants.NSXV3_SERVER_RPC_TOPIC,
-                             [nsxv3_rpc.NSXv3ServerRpcCallback()], 
+                             [nsxv3_rpc.NSXv3ServerRpcCallback()],
                              fanout=False)
         conn.consume_in_threads()
 

--- a/tools/answerfile.yml
+++ b/tools/answerfile.yml
@@ -22,6 +22,7 @@ enable_security_group: "true"
 agent_id: "nsxm-l-01a.corp.local"
 sync_pool_size: "10"
 sync_requests_per_second: "10"
+sync_full_schedule: "24"
 locking_coordinator_url: ""
 # 24 hours = 86400 seconds
 polling_interval: "86400"

--- a/tools/configure_ml2_agent.yml
+++ b/tools/configure_ml2_agent.yml
@@ -29,6 +29,7 @@
         - { section: "AGENT", option: "agent_id", value: "{{ agent_id }}" }
         - { section: "AGENT", option: "sync_pool_size", value: "{{ sync_pool_size }}" }
         - { section: "AGENT", option: "sync_requests_per_second", value: "{{ sync_requests_per_second }}" }
+        - { section: "AGENT", option: "sync_full_schedule", value: "{{ sync_full_schedule }}" }
         - { section: "AGENT", option: "locking_coordinator_url", value: "{{ locking_coordinator_url }}" }
         - { section: "AGENT", option: "polling_interval", value: "{{ polling_interval }}" }
         - { section: "AGENT", option: "quitting_rpc_timeout", value: "{{ quitting_rpc_timeout }}" }


### PR DESCRIPTION
Add full synchronization that will force check all of the firewall rules
If a rule was changed or disabled it will be fixed

Bugfix - do not increase openstack revision number in on NSX-T objects
in case there is even a single firewall rule failure.
This way we can force rule update/create on the next sync