### PR TITLE
Set timeout for vapi requests_connector

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_client.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_client.py
@@ -189,9 +189,11 @@ class NSXv3ClientImpl(NSXv3Client):
         self.session.headers["Accept"] = "application/json"
         self.session.headers["Content-Type"] = "application/json"
 
+        timeout = cfg.CONF.NSXV3.nsxv3_request_timeout
         conr = connect.get_requests_connector(session=self.session,
                                               msg_protocol='rest',
-                                              url=self.base_url)
+                                              url=self.base_url,
+                                              timeout=timeout)
         self.stub_config = StubConfigurationFactory.new_std_configuration(conr)
         LOG.info("NSXv3 session context initalized.")
 


### PR DESCRIPTION
The default timeout being None means endless waiting for a request to
finish. This leads to a thread taking a lock endlessly, which, after
some time, will lead to all worker threads hanging on that lock and the
agent doing nothing.

While request's Session doesn't support a timeout, the vapi does. It
uses it explicitly on every request it makes. One can still use a
different one per request by providing the timeout parameter to the
request.