### PR TITLE
Fix TypeError for egress rules with destination

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_utils.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_utils.py
@@ -22,7 +22,7 @@ from uuid import UUID
 def get_firewall_rule_ipset(sdk_model):
     if sdk_model.sources and hasattr(sdk_model.sources[0], '__ipset'):
         return sdk_model.sources[0].__ipset
-    if sdk_model.destinations and "__ipset" in sdk_model.destinations[0]:
+    if sdk_model.destinations and hasattr(sdk_model.destinations[0], '__ipset'):
         return sdk_model.destinations[0].__ipset
 
 # The method is related to NSX 0.0.0.0/x rule issue


### PR DESCRIPTION
In the last patch, we introduced some code checking for `__ipset` as a
dictionary member instead of an attribute. This leads to a TypeError for
FirewallSections having an egress target:

	Traceback (most recent call last):
	  File "/var/lib/openstack/local/lib/python2.7/site-packages/eventlet/greenpool.py", line 82, in _spawn_n_impl
		func(*args, **kwargs)
	  File "/var/lib/openstack/src/networking-nsxv3/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_agent.py", line 141, in security_group_rule_updated
		del_rules=del_rules)
	  File "/var/lib/openstack/src/networking-nsxv3/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_facada.py", line 628, in update_security_group_rules
		data_ipset = nsxv3_utils.get_firewall_rule_ipset(sdk_obj)
	  File "/var/lib/openstack/src/networking-nsxv3/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_utils.py", line 25, in get_firewall_rule_ipset
		if sdk_model.destinations and "__ipset" in sdk_model.destinations[0]:
	TypeError: argument of type 'ResourceReference' is not iterable