### PR TITLE
Configure default revision_number for IPSet

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_agent.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_agent.py
@@ -70,7 +70,9 @@ class NSXv3AgentManagerRpcCallBackBase(amb.CommonAgentManagerRpcCallBackBase):
         sg_id = str(security_group_id)
         LOG.debug("Updating Security Group '{}'".format(sg_id))
         with LockManager.get_lock(sg_id):
-            self.nsxv3.get_or_create_security_group(sg_id)
+            (ipset, _, _) = self.nsxv3.get_or_create_security_group(sg_id)
+
+            self.nsxv3.update_security_group_revision_number(ipset)
 
             tcp_strict_enabled = self.rpc.has_security_group_tag(
                 security_group_id, nsxv3_constants.NSXV3_CAPABILITY_TCP_STRICT)

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_facada.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_facada.py
@@ -614,15 +614,10 @@ class NSXv3Facada(nsxv3_client.NSXv3ClientImpl):
         default_tag = Tag(scope=nsxv3_constants.NSXV3_REVISION_SCOPE, tag="-1")
 
         sdk_model.tags = sdk_model.tags if sdk_model.tags else []
-        revision = None
-        for tag in sdk_model.tags:
-            if tag.scope == default_tag.scope:
-                revision = tag.tag
-                break
-        if revision is None or not sdk_model.tags:
-            sdk_model.tags.append(default_tag)
-            sdk_model = self.update(sdk_service=IpSets, sdk_model=sdk_model)
-        return sdk_model
+        if default_tag.scope in (t.scope for t in sdk_model.tags):
+            return sdk_model
+        sdk_model.tags.append(default_tag)
+        return self.update(sdk_service=IpSets, sdk_model=sdk_model)
 
     def update_security_group_members(self, security_group_id, member_cidrs):
         ips_spec = IPSet(display_name=security_group_id)


### PR DESCRIPTION
Issue
Unable to populate rules referencing to a remote security group (IPSet)
that does not have reviion number

Resolution
Set default revision_number to all IPSets during creation

Side Effect
For existing security groups where this issue is still active
force update with default revision_number.
The update should be realized during the firt shallow or full sync.