### PR TITLE
Revert "Bind only known networks"

### DIFF
--- a/networking_nsxv3/common/config.py
+++ b/networking_nsxv3/common/config.py
@@ -65,10 +65,6 @@ agent_opts = [
         'agent_prometheus_exporter_port',
         default='8000',
         help="Prometheus exporter port"
-    ),
-    cfg.MultiStrOpt('agent_physical_networks',
-        default=[],
-        help="List of physical networks that the Agent can bind"
     )
 ]
 

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/driver.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/driver.py
@@ -93,7 +93,6 @@ class VMwareNSXv3MechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         agent_alive = agent.get('alive', False)
         agent_type = agent['agent_type']
         host = agent.get('host', None)
-        networks = cfg.CONF.AGENT.agent_physical_networks
 
         if not device.startswith('compute'):
             LOG.warn(
@@ -115,11 +114,6 @@ class VMwareNSXv3MechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
 
         if not host == context.current['binding:host_id']:
             LOG.warn("Not supported host. Host=" + str(host))
-            return False
-
-        if segment['physical_network'] not in networks:
-            LOG.warn("Not supported network. Network=" +\
-                str(segment['physical_network']))
             return False
 
         response = self.rpc.get_network_bridge(

--- a/tools/answerfile.yml
+++ b/tools/answerfile.yml
@@ -27,7 +27,6 @@ polling_interval: "86400"
 quitting_rpc_timeout: "5"
 rpc_max_records_per_query: "2000"
 agent_prometheus_exporter_port: "8000"
-agent_physical_networks: "bb99-vlan-99999"
 
 # AGENT_CLI
 neutron_security_group_id:

--- a/tools/configure_ml2_agent.yml
+++ b/tools/configure_ml2_agent.yml
@@ -33,7 +33,6 @@
         - { section: "AGENT", option: "quitting_rpc_timeout", value: "{{ quitting_rpc_timeout }}" }
         - { section: "AGENT", option: "rpc_max_records_per_query", value: "{{ rpc_max_records_per_query }}" }
         - { section: "AGENT", option: "agent_prometheus_exporter_port", value: "{{ agent_prometheus_exporter_port }}" }
-        - { section: "AGENT", option: "agent_physical_networks", value: "{{ agent_physical_networks }}" }
         - { section: "AGENT_CLI", option: "neutron_security_group_id", value: "{{ neutron_security_group_id }}" }
         - { section: "AGENT_CLI", option: "neutron_port_id", value: "{{ neutron_port_id }}" }
         - { section: "AGENT_CLI", option: "neutron_qos_policy_id", value: "{{ neutron_qos_policy_id }}" }


### PR DESCRIPTION
Hi,

had to revert the physical_network check (cfg not imported), I know I requested it some time ago, but I wonder why, since the physical_network inside the segment is set by ACI and should be always correct. I think we can live without additional check since we already checking the host.

This reverts commit da9362c9d6c100224132a27bedae8df7fee89314.
