### PR TITLE
Feature/queens cli

### DIFF
--- a/networking_nsxv3/common/config.py
+++ b/networking_nsxv3/common/config.py
@@ -71,14 +71,14 @@ agent_opts = [
 agent_cli_opts = [
     cfg.MultiStrOpt('neutron_security_group_id',
                     default=[],
-                    help="Neutron Security Group IDs synchronization targets."
+                    help="Neutron Security Group IDs synchronization targets. Use '*' to match all."
                     ),
     cfg.MultiStrOpt('neutron_port_id',
                     default=[],
-                    help="Neutron Port IDs synchronization targets."),
+                    help="Neutron Port IDs synchronization targets. Use '*' to match all."),
     cfg.MultiStrOpt('neutron_qos_policy_id',
                     default=[],
-                    help="Neutron QoS Policy IDs synchronization targets.")
+                    help="Neutron QoS Policy IDs synchronization targets. Use '*' to match all.")
 ]
 
 nsxv3_opts = [
@@ -173,6 +173,11 @@ nsxv3_opts = [
         help="NSXv3 Manager DFW connectivity strategy: {}"\
             .format(str(nsxv3_dfw_connectivity_strategy))
     ),
+    cfg.BoolOpt('nsxv3_groups_disconnect',
+        default=False,
+        help="Remvoe dynamic membership criteria from security groups."
+        # NSX-T objects will be created but not enforced on the segment ports
+    )
 ]
 
 vsphere_opts = [

--- a/networking_nsxv3/common/config.py
+++ b/networking_nsxv3/common/config.py
@@ -65,6 +65,16 @@ agent_opts = [
         'agent_prometheus_exporter_port',
         default='8000',
         help="Prometheus exporter port"
+    ),
+    cfg.IntOpt(
+        'retry_on_failure_max',
+        default=0,
+        help="Maximum retries of a failed object synchronization"
+    ),
+    cfg.IntOpt(
+        'retry_on_failure_delay',
+        default=10,
+        help="Delay between retries of a failed object synchronization in seconds"
     )
 ]
 

--- a/networking_nsxv3/common/synchronization.py
+++ b/networking_nsxv3/common/synchronization.py
@@ -104,9 +104,9 @@ class Runner(object):
 
     def stop(self):
         """ Gracefully terminates the runner instance """
+        self._workers.waitall()
         self._active.join()
         self._passive.join()
-        self._workers.waitall()
 
 
 class Scheduler(object):

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_agent.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_agent.py
@@ -770,6 +770,15 @@ def cli_sync():
     execute(rpc.sync_qos, rpc.sync_qos, qs_ids)
     manager.shutdown_gracefully()
 
+    uninitialized = -1
+    while uninitialized:
+        res = nsxv3.get_uninitalized_policies()
+        if res.ok:
+            uninitialized = res.json().get('result_count', -1)
+
+        LOG.info("Waiting for %d uninitalized Policies", uninitialized)
+        eventlet.sleep(10)
+
 
 def main():
     common_config.init(sys.argv[1:])

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_facada.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_facada.py
@@ -4,6 +4,7 @@ from oslo_config import cfg
 import copy
 import json
 import datetime
+import urllib
 
 from com.vmware.nsx_client import LogicalSwitches
 from com.vmware.nsx_client import TransportZones
@@ -682,3 +683,9 @@ class NSXv3Facada(nsxv3_client.NSXv3ClientImpl):
             for tag in obj.tags:
                 tags[tag.scope] = tag.tag
         return tags
+
+    def get_uninitalized_policies(self):
+        query = '_exists_:resource_type AND !resource_type:(GenericPolicyRealizedResource OR Domain) AND !_exists_:nsx_id AND !_create_user:nsx_policy'
+        dsl = 'security policy where status != SUCCESS'
+        params = (('query', query), ('dsl', dsl))
+        return self._get(path="/policy/api/v1/search?{}".format(urllib.urlencode(params)))

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_policy.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_policy.py
@@ -193,7 +193,8 @@ class AgentIdentifier:
 
 class InfraBuilder:
 
-    def __init__(self, client, transport_zone_id=None):
+    def __init__(self, client, transport_zone_id=None, options=None):
+        self._options = options if options else {}
         self._client = client
         self.context = {
             "resource_type": "Infra",
@@ -247,7 +248,7 @@ class InfraBuilder:
             "conjunction_operator": "OR"
         }
 
-        if group.dynamic_members:
+        if not self._options.get('groups_dynamic_members_off') and group.dynamic_members:
             # NSX-T treats Segment Ports and Logical Ports the same way when
             # specified at member_type
             expression.append({
@@ -508,6 +509,9 @@ class InfraService:
         self._client = client
         self._page_size = cfg.CONF.NSXV3.nsxv3_max_records_per_query
         self._transport_zone_name = cfg.CONF.NSXV3.nsxv3_transport_zone_name
+        self._infra_options = {
+            "groups_dynamic_members_off": bool(cfg.CONF.NSXV3.nsxv3_groups_disconnect)
+        }
 
     def _get_tags(self, resource):
         tags = {}
@@ -607,7 +611,7 @@ class InfraService:
         builder.build()
 
     def get_builder(self):
-        return InfraBuilder(self._client)
+        return InfraBuilder(self._client, options=self._infra_options)
 
 class ResourceContainers:
     TransportZone = "/sites/default/enforcement-points/default/transport-zones"

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_policy.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_policy.py
@@ -253,7 +253,7 @@ class InfraBuilder:
             # specified at member_type
             expression.append({
                 "value": "security_group|" + identifier,
-                "member_type": "SegmentPort",
+                "member_type": "LogicalPort",
                 "key": "Tag",
                 "operator": "EQUALS",
                 "resource_type": "Condition"

--- a/tools/answerfile.yml
+++ b/tools/answerfile.yml
@@ -51,3 +51,4 @@ nsxv3_managed_hosts:
 nsxv3_max_records_per_query: "2000"
 nsxv3_remove_orphan_ports_after: "12"
 nsxv3_dfw_connectivity_strategy: "NONE"
+nsxv3_groups_disconnect: False

--- a/tools/answerfile.yml
+++ b/tools/answerfile.yml
@@ -22,6 +22,8 @@ enable_security_group: "true"
 agent_id: "nsxm-l-01a.corp.local"
 sync_full_schedule: "24"
 locking_coordinator_url: ""
+retry_on_failure_max: 0
+retry_on_failure_delay: 10
 # 24 hours = 86400 seconds
 polling_interval: "86400"
 quitting_rpc_timeout: "5"

--- a/tools/configure_ml2_agent.yml
+++ b/tools/configure_ml2_agent.yml
@@ -33,6 +33,8 @@
         - { section: "AGENT", option: "quitting_rpc_timeout", value: "{{ quitting_rpc_timeout }}" }
         - { section: "AGENT", option: "rpc_max_records_per_query", value: "{{ rpc_max_records_per_query }}" }
         - { section: "AGENT", option: "agent_prometheus_exporter_port", value: "{{ agent_prometheus_exporter_port }}" }
+        - { section: "AGENT", option: "retry_on_failure_max", value: "{{ retry_on_failure_max }}" }
+        - { section: "AGENT", option: "retry_on_failure_delay", value: "{{ retry_on_failure_delay }}" }
         - { section: "AGENT_CLI", option: "neutron_security_group_id", value: "{{ neutron_security_group_id }}" }
         - { section: "AGENT_CLI", option: "neutron_port_id", value: "{{ neutron_port_id }}" }
         - { section: "AGENT_CLI", option: "neutron_qos_policy_id", value: "{{ neutron_qos_policy_id }}" }

--- a/tools/configure_ml2_agent.yml
+++ b/tools/configure_ml2_agent.yml
@@ -53,6 +53,7 @@
         - { section: "NSXV3", option: "nsxv3_max_records_per_query", value: "{{ nsxv3_max_records_per_query }}" }
         - { section: "NSXV3", option: "nsxv3_remove_orphan_ports_after", value: "{{ nsxv3_remove_orphan_ports_after }}" }
         - { section: "NSXV3", option: "nsxv3_dfw_connectivity_strategy", value: "{{ nsxv3_dfw_connectivity_strategy }}" }
+        - { section: "NSXV3", option: "nsxv3_groups_disconnect", value: "{{ nsxv3_groups_disconnect }}" }
     - name: Start agent as daemon
       shell: screen -dmS neutron-nsxv3-agent /usr/local/bin/neutron-nsxv3-agent --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/ml2_conf.ini
       become: yes


### PR DESCRIPTION
For the migration scenario:
1. Run the Management Agent.
2. Run in parallel the CLI with a security group sync value.
to set to '*' and CFG option groups_dynamic_members_off=True.
3. Run the Policy Agent with groups_dynamic_members_off=False.
By performing 1-3 the agent will synchronize both the policy and management
API objects to the Neutron revisions. Management objects will remain active
until there is an update on them, which will cause an update on the policy
an object that will activate the group membership, increase the revision number
and finally, remove the management object as it is going to have a lower version.