### PR TITLE
Pass object via id to ObjectNotFound

### DIFF
--- a/networking_nsxv3/db/db.py
+++ b/networking_nsxv3/db/db.py
@@ -21,11 +21,10 @@ from neutron_lib import exceptions
 
 
 def _validate_one(result, error):
-    msg = "{} not found in Neutron."
     if result:
         return result
     else:
-        raise exceptions.ObjectNotFound(msg.format(error))
+        raise exceptions.ObjectNotFound(id=error)
 
 
 def _get_datetime(datetime_value):


### PR DESCRIPTION
ObjectNotFound does not take any positional arguments, but takes an id
as keyword argument. Strictly speaking we don't have an id, but the
exception would look decent enough:

"Object Security Group '7bf...' not found."