### PR TITLE
Add default logging policy

### DIFF
--- a/networking_nsxv3/common/constants.py
+++ b/networking_nsxv3/common/constants.py
@@ -17,6 +17,13 @@ NSXV3_SECURITY_GROUP_RULE_BATCH_SIZE = 265
 NSXV3_REVISION_SCOPE = "revision_number"
 NSXV3_AGENT_SCOPE = "agent_id"
 
+# DFW Logging
+NSXV3_LOGGING_SCOPE = "logging"
+NSXV3_LOGGING_ENABLED = "enabled"
+NSXV3_DEFAULT_POLICY_ID = "DefaultML2Policy"
+NSXV3_DEFAULT_LOGGING_ID = "DefaultLoggingRule"
+
+# Migration DVS to NVDS
 NSXV3_MIGRATION_SCOPE = "vswitch_migration_target"
 NSXV3_MIGRATION_TAG_DVS = "dvs"
 NSXV3_MIGRATION_TAG_NVDS = "nvds"

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_facada.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/nsxv3_facada.py
@@ -198,10 +198,16 @@ class NSXv3Facada(nsxv3_client.NSXv3ClientImpl):
         sg_scope = nsxv3_constants.NSXV3_SECURITY_GROUP_SCOPE
         rev_scope = nsxv3_constants.NSXV3_REVISION_SCOPE
         agent_scope = nsxv3_constants.NSXV3_AGENT_SCOPE
+        logging_scope = nsxv3_constants.NSXV3_LOGGING_SCOPE
+        logging_tag = nsxv3_constants.NSXV3_LOGGING_ENABLED
 
         lp.tags = [
             Tag(scope=sg_scope, tag=id) for id in port["security_groups"]
         ]
+
+        if port["logging"]:
+            lp.tags.append(Tag(scope=logging_scope, tag=logging_tag))
+
         lp.tags.append(Tag(scope=rev_scope, tag=str(port["revision_number"])))
         lp.tags.append(Tag(scope=agent_scope, tag=str(self.agent_id)))
         lp.switching_profile_ids = []
@@ -627,6 +633,9 @@ class NSXv3Facada(nsxv3_client.NSXv3ClientImpl):
         ands = [attr_val] if attr_val else []
 
         def is_managed_by(obj):
+            # Skip updats for the Default Policy
+            if obj.get("id") == nsxv3_constants.NSXV3_DEFAULT_POLICY_ID:
+                return False
             for tag in obj.get("tags"):
                 if tag.get("scope") == nsxv3_constants.NSXV3_AGENT_SCOPE\
                     and tag.get("tag") == self.agent_id:


### PR DESCRIPTION
The default logging policy REJECTs the traffic form
the ports with enabled logging and generate logs for this rejected
traffic.
It is required as the security groups only allow traffic and when
logging is enabled for them and the traffic does not match it is
termiated by the Default L2 Section. Now with the default logging
policy we place it right before the Default L2 Section which enables
the NSX manager to capture the DWF debug logs.

The policy is active only for the ports enabled for logging.
The policy uses Logging Group with memberhsip criteria by tag with
scope := logging, tag := enabled