### PR TITLE
This commit adds github action tox tests

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -1,0 +1,36 @@
+  # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Unit Tests
+
+on:
+  push:
+    branches: [ stable/quuens-m3 ]
+  pull_request:
+    branches: [ stable/queens-m3 ]
+
+env:
+  UPPER_CONSTRAINTS_FILE: https://raw.githubusercontent.com/sapcc/requirements/stable/queens-m3/upper-constraints.txt
+  VIRTUALENV_PIP: "20.2.3"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [2.7]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Tox and any other packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install build-essential netbase
+          pip install tox
+      - name: Tox
+        run: tox -e py

--- a/networking_nsxv3/tests/unit/test_provider_nsx_mgmt.py
+++ b/networking_nsxv3/tests/unit/test_provider_nsx_mgmt.py
@@ -62,12 +62,8 @@ class TestProvider(base.BaseTestCase):
         ipp = "{}-{}".format(cfg.CONF.AGENT.agent_id, "IpDiscovery")
 
         self.assertEquals(len(profiles), 2)
-
-        keys = profiles.keys()
-
-        self.assertEquals(profiles.get(keys[0]).get("display_name"), sgp)
-        self.assertEquals(profiles.get(keys[1]).get("display_name"), ipp)
-
+        realized_profiles = [profiles.get(key).get("display_name") for key in profiles.keys()]
+        self.assertEqual([sgp, ipp], realized_profiles)
 
     @responses.activate
     def test_security_group_members_creation_diverse_cidrs(self):

--- a/networking_nsxv3/tests/unit/test_provider_nsx_mgmt.py
+++ b/networking_nsxv3/tests/unit/test_provider_nsx_mgmt.py
@@ -63,7 +63,8 @@ class TestProvider(base.BaseTestCase):
 
         self.assertEquals(len(profiles), 2)
         realized_profiles = [profiles.get(key).get("display_name") for key in profiles.keys()]
-        self.assertEqual([sgp, ipp], realized_profiles)
+        self.assertIn(sgp, realized_profiles)
+        self.assertIn(ipp, realized_profiles)
 
     @responses.activate
     def test_security_group_members_creation_diverse_cidrs(self):

--- a/networking_nsxv3/tests/unit/test_provider_nsx_mgmt.py
+++ b/networking_nsxv3/tests/unit/test_provider_nsx_mgmt.py
@@ -44,6 +44,7 @@ class TestProvider(base.BaseTestCase):
 
         logging.setup(cfg.CONF, "demo")
         logging.set_defaults(default_log_levels=["networking_nsxv3=DEBUG", "root=DEBUG"])
+        cfg.CONF.set_override("nsxv3_cache_refresh_window", 0, "NSXV3")
 
         self.inventory = Inventory("https://nsxm-l-01a.corp.local:443")
         r = responses

--- a/networking_nsxv3/tests/unit/test_provider_nsx_policy.py
+++ b/networking_nsxv3/tests/unit/test_provider_nsx_policy.py
@@ -44,6 +44,7 @@ class TestProvider(base.BaseTestCase):
 
         logging.setup(cfg.CONF, "demo")
         logging.set_defaults(default_log_levels=["networking_nsxv3=DEBUG", "root=DEBUG"])
+        cfg.CONF.set_override("nsxv3_cache_refresh_window", 0, "NSXV3")
 
         self.inventory = Inventory("https://nsxm-l-01a.corp.local:443", version="3.0.2")
         r = responses

--- a/networking_nsxv3/tests/unit/test_realization.py
+++ b/networking_nsxv3/tests/unit/test_realization.py
@@ -19,8 +19,6 @@ from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import realization
 from networking_nsxv3.tests.unit import provider
 from networking_nsxv3.tests.unit import openstack
 
-from networking_nsxv3.tests.unit import rpc
-
 import re
 import json
 import eventlet
@@ -86,6 +84,7 @@ class TestAgentRealizer(base.BaseTestCase):
 
         logging.setup(cfg.CONF, "demo")
         logging.set_defaults(default_log_levels=["networking_nsxv3=DEBUG", "root=DEBUG"])
+        cfg.CONF.set_override("nsxv3_cache_refresh_window", 0, "NSXV3")
 
         self.provider_inventory = provider.Inventory("https://nsxm-l-01a.corp.local:443")
         self.openstack_inventory = openstack.Inventory()
@@ -114,7 +113,7 @@ class TestAgentRealizer(base.BaseTestCase):
         child_port = self.openstack_inventory.port_create("p1-1", "3201", parent_name="p1")
         child_port = self.openstack_inventory.port_update("p1-1", security_group_names=[])
 
-        eventlet.sleep(1.1)
+        eventlet.sleep(5.0)
 
         p_inv = self.provider_inventory
         LOG.info(json.dumps(p_inv.inventory, indent=4))
@@ -123,7 +122,7 @@ class TestAgentRealizer(base.BaseTestCase):
 
 
         provider_ports = [o.get("display_name") for _,o in p_inv.inventory.get(p_inv.PORTS).items()]
-        self.assertEquals(set(provider_ports), set([port.get("id"), child_port.get("id")]))
+        self.assertEqual(set(provider_ports), set([port.get("id"), child_port.get("id")]))
 
         self.manager.shutdown()
 
@@ -164,13 +163,13 @@ class TestAgentRealizer(base.BaseTestCase):
         LOG.info(json.dumps(self.openstack_inventory.inventory, indent=4))
         LOG.info(json.dumps(self.manager.realizer.provider._cache, indent=4))
 
-        self.assertNotEquals(p_inv.lookup(p_inv.NSGROUPS, sg_02.get("id")), None)
-        self.assertNotEquals(p_inv.lookup(p_inv.SECTIONS, sg_02.get("id")), None)
-        self.assertNotEquals(p_inv.lookup(p_inv.IPSETS, sg_01.get("id")), None)
-        self.assertNotEquals(p_inv.lookup(p_inv.IPSETS, sg_02_rule.get("id")), None)
-        self.assertEquals(len(p_inv.lookup(p_inv.SECTIONS, sg_02.get("id")).get("_").get("rules").keys()), 3)
-        self.assertEquals(len(p_inv.inventory.get(p_inv.IPSETS).keys()), 3)
-        self.assertNotEquals(p_inv.lookup(p_inv.PROFILES, qos_01.get("id")), None)
+        self.assertNotEqual(p_inv.lookup(p_inv.NSGROUPS, sg_02.get("id")), None)
+        self.assertNotEqual(p_inv.lookup(p_inv.SECTIONS, sg_02.get("id")), None)
+        self.assertNotEqual(p_inv.lookup(p_inv.IPSETS, sg_01.get("id")), None)
+        self.assertNotEqual(p_inv.lookup(p_inv.IPSETS, sg_02_rule.get("id")), None)
+        self.assertEqual(len(p_inv.lookup(p_inv.SECTIONS, sg_02.get("id")).get("_").get("rules").keys()), 3)
+        self.assertEqual(len(p_inv.inventory.get(p_inv.IPSETS).keys()), 3)
+        self.assertNotEqual(p_inv.lookup(p_inv.PROFILES, qos_01.get("id")), None)
 
         sgs = []
         for i in range(1,3):
@@ -194,12 +193,12 @@ class TestAgentRealizer(base.BaseTestCase):
         LOG.info(json.dumps(self.openstack_inventory.inventory, indent=4))
         LOG.info(json.dumps(self.manager.realizer.provider._cache, indent=4))        
         
-        self.assertEquals(p_inv.inventory.get(p_inv.NSGROUPS).keys(), [])
-        self.assertEquals(p_inv.inventory.get(p_inv.SECTIONS).keys(), [])
-        self.assertEquals(p_inv.inventory.get(p_inv.IPSETS).keys(), [])
-        self.assertEquals(p_inv.inventory.get(p_inv.PORTS).keys(), [])
+        self.assertEqual(p_inv.inventory.get(p_inv.NSGROUPS).keys(), [])
+        self.assertEqual(p_inv.inventory.get(p_inv.SECTIONS).keys(), [])
+        self.assertEqual(p_inv.inventory.get(p_inv.IPSETS).keys(), [])
+        self.assertEqual(p_inv.inventory.get(p_inv.PORTS).keys(), [])
         # Default IP-Discovery and Spoofguard
-        self.assertEquals(len(p_inv.inventory.get(p_inv.PROFILES).keys()), 2)
+        self.assertEqual(len(p_inv.inventory.get(p_inv.PROFILES).keys()), 2)
 
         self.manager.shutdown()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@
 pbr>=1.6
 Babel>=1.3
 
-neutron>=13.0.0.0b1             # Apache-2.0
 neutron-lib>=1.13.0             # Apache-2.0
 oslo.config>=2.3.0              # Apache-2.0
 oslo.i18n>=1.5.0                # Apache-2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
+neutron==12.1.1 # Apache-2.0
 hacking!=0.13.0,<0.14,>=0.12.0 # Apache-2.0
 coverage!=4.4,>=4.0 # Apache-2.0
 ddt>=1.0.1 # MIT
@@ -17,7 +18,7 @@ sphinx!=1.6.6,>=1.6.2 # BSD
 sphinxcontrib-actdiag>=0.8.5 # BSD
 sphinxcontrib-seqdiag>=0.8.4 # BSD
 os-api-ref>=1.4.0 # Apache-2.0
-# oslotest>=3.2.0 # Apache-2.0
+oslotest>=3.2.0 # Apache-2.0
 stestr>=1.0.0 # Apache-2.0
 osprofiler>=1.4.0 # Apache-2.0
 testresources>=2.0.0 # Apache-2.0/BSD

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,7 @@ basepython = python2.7
 commands =
     {[testenv]commands}
     stestr run '{posargs}'
-    env TEST_OSPROFILER=1 stestr run --combine --no-discover 'networking_nsxv3/tests/unit/test_provider_nsx_mgmt'
-    env TEST_OSPROFILER=1 stestr run --combine --no-discover 'networking_nsxv3/tests/unit/test_realization'
+    env TEST_OSPROFILER=1 stestr run --combine --no-discover 'networking_nsxv3/tests/unit'
     stestr slowest
 
 [testenv:pep8]

--- a/tox.ini
+++ b/tox.ini
@@ -10,14 +10,15 @@ whitelist_externals = bash
                       find
                       rm
                       env
-install_command = python -m pip install -c {env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/queens} {opts} {packages}
+install_command = python -m pip install {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
          LANGUAGE=en_US
          LC_ALL=en_US.utf-8
          OS_STDOUT_CAPTURE=1
          OS_STDERR_CAPTURE=1
          OS_TEST_TIMEOUT=160
-deps = -r{toxinidir}/test-requirements.txt 
+deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/queens}
+       -r{toxinidir}/test-requirements.txt 
        -r{toxinidir}/requirements.txt
 commands = 
     python setup.py testr --slowest --testr-args='{posargs}'


### PR DESCRIPTION
* moved neutron dependency to test-requirement and force version to queens neutron
* adapted tox with some minor improvements
* override nsxv3_cache_refresh_window=0 for much faster tests (and avoiding timeouts)
* re-added oslotest as test requirements (required by neutron-tests)
* renamed deprecated asserts