### PR TITLE
Ignore ports and therefor deletion of ports that have non-agent logic…

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
@@ -58,7 +58,6 @@ class NSXv3AgentManagerRpcCallBackBase(amb.CommonAgentManagerRpcCallBackBase):
 
         network_meta = dict()
         for ns in network_segments:
-            cfg.CONF.NSXV3.nsxv3_transport_zone_name
             seg_id = ns.get("segmentation_id")
             net_type = ns.get("network_type")
             if seg_id and net_type in nsxv3_constants.NSXV3_AGENT_NETWORK_TYPES:

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_mgmt.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_mgmt.py
@@ -624,6 +624,16 @@ class Provider(abs.Provider):
                         if resource_type == Provider.SG_RULES:
                             if not res.has_valid_os_uuid:
                                 continue
+                        if resource_type == Provider.PORT:
+                            # Ensure this port is attached to a agent managed
+                            # logical switch, else skip it
+                            is_valid_vlan = False
+                            for name, ls in self._metadata[Provider.NETWORK].meta.meta.items():
+                                if ls.id == res.resource.get('logical_switch_id') and name.isnumeric():
+                                    is_valid_vlan = True
+                                    break
+                            if not is_valid_vlan:
+                                continue
                         provider.meta.add(res)
 
     def metadata_delete(self, resource_type, os_id):

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
@@ -63,6 +63,9 @@ class AgentRealizer(object):
             sg_meta = self._os_meta(r.get_security_groups_with_revisions)
             qos_meta = self._os_meta(r.get_qos_policies_with_revisions)
 
+            # Only force networks refresh
+            p.metadata_refresh(p.NETWORK)
+
             # Refresh entire metadata with its latest state
             LOG.info("Inventory metadata is going to be refreshed.")
             port_outdated, port_current = p.outdated(p.PORT, port_meta)
@@ -74,8 +77,6 @@ class AgentRealizer(object):
 
             # There is not way to revision group members but can 'age' them
             sgm_outdated, _ = p.outdated(p.SG_MEMBERS, {sg: 0 for sg in sg_meta})
-            # Only force networks refresh
-            p.metadata_refresh(p.NETWORK)
             LOG.info("Inventory metadata have been refreshed.")
 
             if dryrun:


### PR DESCRIPTION
…al switches

logical ports are ignore if they attached to a logical switch which don't
have a numerical ('bla-bla-1234') display name suffix. This is needed to ensure
privileged logical ports from esxi (e.g. vmotion ports) are not handled
by the agent..