### PR TITLE
Ignore exceptions on double group creation

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
@@ -11,6 +11,7 @@ from networking_nsxv3.common.locking import LockManager
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import provider_nsx_mgmt
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.constants_nsx import *
 from networking_nsxv3.prometheus import exporter
+import json
 
 LOG = logging.getLogger(__name__)
 
@@ -315,10 +316,10 @@ class Provider(provider_nsx_mgmt.Provider):
             return self.client.put(path=path, data=data).json()
         except Exception as e:
             with excutils.save_and_reraise_exception() as ctxt:
-                if 'already exists' in e.message:
+                if 'already exists' in e.args[1]:
                     ctxt.reraise = False
                     return self.client.patch(path=path, data=data).json()
-                return id
+                ctxt.reraise = True
     
     def _delete_sg_provider_rule_remote_prefix(self, id):
         self.client.delete(path=API.GROUP.format(id))

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
@@ -11,7 +11,6 @@ from networking_nsxv3.common.locking import LockManager
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import provider_nsx_mgmt
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.constants_nsx import *
 from networking_nsxv3.prometheus import exporter
-import json
 
 LOG = logging.getLogger(__name__)
 
@@ -84,7 +83,7 @@ class Payload(provider_nsx_mgmt.Payload):
             "display_name": cidr,
             "expression": [{
                 "resource_type": "IPAddressExpression",
-                "ip_addresses": [cidr]   
+                "ip_addresses": [cidr]
             }],
             "tags": self.tags(None)
         }
@@ -126,7 +125,7 @@ class Payload(provider_nsx_mgmt.Payload):
         if err:
             LOG.error("Not supported service for Rule:%s. Error:%s", os_id, err)
             return
-        
+
         service_entries = [service] if service else []
 
         res = {
@@ -219,7 +218,7 @@ class Provider(provider_nsx_mgmt.Provider):
                 LOG.info("%s ID:%s in Status:%s for %ss", resource_type, os_id, status, attempt*pause)
                 eventlet.sleep(pause)
         # When multiple policies did not get realized in the defined timeframe,
-        # this is a symptom for another issue. 
+        # this is a symptom for another issue.
         # This should be detected by the Prometheus after a while
         exporter.REALIZED.labels(resource_type, status).inc()
         raise Exception("{} ID:{} did not get realized for {}s", resource_type, os_id, until * pause)
@@ -232,8 +231,8 @@ class Provider(provider_nsx_mgmt.Provider):
             return super(Provider, self)._realize(resource_type, delete, convertor, os_o, provider_o)
 
         os_id = provider_id = os_o.get("id")
-        
-        report = "Resource:{} with ID:{} is going to be %s.".format(resource_type, os_id)        
+
+        report = "Resource:{} with ID:{} is going to be %s.".format(resource_type, os_id)
 
         meta = self.metadata(resource_type, os_id)
         if meta:
@@ -319,8 +318,7 @@ class Provider(provider_nsx_mgmt.Provider):
                 if 'already exists' in e.args[1]:
                     ctxt.reraise = False
                     return self.client.patch(path=path, data=data).json()
-                ctxt.reraise = True
-    
+
     def _delete_sg_provider_rule_remote_prefix(self, id):
         self.client.delete(path=API.GROUP.format(id))
 
@@ -328,7 +326,7 @@ class Provider(provider_nsx_mgmt.Provider):
     def sanitize(self, slice):
         if slice <= 0:
             return ([], None)
-            
+
         def remove_orphan_service(provider_id):
             self.client.delete(path=API.SERVICE.format(provider_id))
 

--- a/networking_nsxv3/tests/unit/test_provider_nsx_policy.py
+++ b/networking_nsxv3/tests/unit/test_provider_nsx_policy.py
@@ -3,7 +3,6 @@ import json
 import re
 import uuid
 
-import requests
 import responses
 from networking_nsxv3.common import config
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import \
@@ -63,7 +62,7 @@ class TestProviderPolicy(base.BaseTestCase):
         }
 
         provider_nsx_policy.Provider().sg_members_realize(sg)
-        
+
         inv = self.inventory.inventory
         sg_group = self.get_by_name(inv[Inventory.GROUPS], sg["id"])
 
@@ -84,7 +83,7 @@ class TestProviderPolicy(base.BaseTestCase):
         }
 
         provider_nsx_policy.Provider().sg_members_realize(sg)
-        
+
         inv = self.inventory.inventory
         sg_group = self.get_by_name(inv[Inventory.GROUPS], sg["id"])
 
@@ -94,7 +93,7 @@ class TestProviderPolicy(base.BaseTestCase):
                 ip_addresses = e.get("ip_addresses")
                 break
         self.assertEquals(ip_addresses, ["172.16.0.0/16"])
-    
+
     @responses.activate
     def test_security_group_members_creation_compact_ipv6_cidrs(self):
         sg = {
@@ -104,7 +103,7 @@ class TestProviderPolicy(base.BaseTestCase):
         }
 
         provider_nsx_policy.Provider().sg_members_realize(sg)
-        
+
         inv = self.inventory.inventory
         sg_group = self.get_by_name(inv[Inventory.GROUPS], sg["id"])
 
@@ -131,10 +130,10 @@ class TestProviderPolicy(base.BaseTestCase):
         }
 
         provider = provider_nsx_policy.Provider()
-        
+
         provider.sg_members_realize(sg)
         provider.sg_members_realize(sgu)
-        
+
         inv = self.inventory.inventory
         sg_group = self.get_by_name(inv[Inventory.GROUPS], sg["id"])
 
@@ -255,7 +254,7 @@ class TestProviderPolicy(base.BaseTestCase):
         sg1 = copy.deepcopy(sg)
         sg1["rules"].append(copy.deepcopy(rule1))
         sg1["rules"].append(copy.deepcopy(rule2))
-    
+
 
         # Add new, update existing, delete existing
         sg2 = copy.deepcopy(sg)
@@ -266,7 +265,7 @@ class TestProviderPolicy(base.BaseTestCase):
 
         inv = self.inventory.inventory
         provider = provider_nsx_policy.Provider()
-        
+
         provider.sg_rules_realize(sg1)
         LOG.info(json.dumps(inv, indent=4))
         policy1 = self.get_by_name(inv[Inventory.POLICIES], sg["id"])
@@ -292,10 +291,10 @@ class TestProviderPolicy(base.BaseTestCase):
         LOG.info(json.dumps(inv, indent=4))
         policy3 = self.get_by_name(inv[Inventory.POLICIES], sg["id"])
         rules = {r.get("id"):r for r in policy3.get("rules")}
-        
+
         self.assertEquals(len(policy3.get("rules")), 0)
 
-        
+
     @responses.activate
     def test_security_group_rules_remote_group(self):
 
@@ -338,7 +337,7 @@ class TestProviderPolicy(base.BaseTestCase):
         rules = {r.get("id"):r for r in policy.get("rules")}
 
         self.assertEquals(
-            rules[rule["id"]].get("source_groups"), 
+            rules[rule["id"]].get("source_groups"),
             ["/infra/domains/default/groups/{}".format(sg_remote["id"])])
 
 
@@ -374,14 +373,14 @@ class TestProviderPolicy(base.BaseTestCase):
         rules = {r.get("id"):r for r in policy.get("rules")}
 
         self.assertEquals(rules[rule["id"]].get("service_entries")[0], {
-            "resource_type": "L4PortSetServiceEntry", 
-            "l4_protocol": "TCP", 
+            "resource_type": "L4PortSetServiceEntry",
+            "l4_protocol": "TCP",
             "source_ports": [
                 "1-65535"
             ],
             "destination_ports": [
                 "443"
-            ] 
+            ]
         })
 
         self.assertEquals(rules[rule["id"]].get("action"), "ALLOW")
@@ -436,12 +435,12 @@ class TestProviderPolicy(base.BaseTestCase):
         rules = {r.get("id"):r for r in policy.get("rules")}
 
         self.assertEquals(rules[rule_hopopt["id"]].get("service_entries")[0], {
-            "resource_type": "IPProtocolServiceEntry", 
+            "resource_type": "IPProtocolServiceEntry",
             "protocol_number": 0
         })
 
         self.assertEquals(rules[rule_0["id"]].get("service_entries")[0], {
-            "resource_type": "IPProtocolServiceEntry", 
+            "resource_type": "IPProtocolServiceEntry",
             "protocol_number": 0
         })
 
@@ -493,7 +492,7 @@ class TestProviderPolicy(base.BaseTestCase):
         self.assertEquals(rules[rule_valid["id"]].get("service_entries")[0], {
             "resource_type": "ICMPTypeServiceEntry",
             "protocol": "ICMPv4",
-            "icmp_code": "1", 
+            "icmp_code": "1",
             "icmp_type": "5"
         })
 
@@ -563,12 +562,12 @@ class TestProviderPolicy(base.BaseTestCase):
 
         provider = provider_nsx_policy.Provider()
         o = provider._create_sg_provider_rule_remote_prefix("0.0.0.0/0")
-        
+
         expected = {
             "display_name": "0.0.0.0/0",
             "expression": [{"resource_type": "IPAddressExpression", "ip_addresses": ["0.0.0.0/0"]}],
             "tags": [{"scope": "agent_id", "tag": "nsxm-l-01a.corp.local"}, {"scope": "age", "tag": 1637251144}],
         }
-        
+
         self.assertEqual(o["display_name"], expected["display_name"])
         self.assertEqual(o["expression"][0]["ip_addresses"][0], expected["expression"][0]["ip_addresses"][0])

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,11 @@ basepython = python3.6
 commands =
     env TEST_OSPROFILER=1 stestr run 'networking_nsxv3.tests.unit'
 
+[testenv:u1]
+basepython = python3.6
+commands =
+    env TEST_OSPROFILER=1 stestr run 'test_double_creation_of_default_group'
+
 [testenv:coverage]
 setenv =
   {[testenv]setenv}

--- a/tox.ini
+++ b/tox.ini
@@ -31,18 +31,13 @@ setenv = VIRTUAL_ENV={envdir}
          NSXV3_TRANSPORT_ZONE_NAME={env:NSXV3_TRANSPORT_ZONE_NAME:}
 
 deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/ussuri}
-       -r{toxinidir}/test-requirements.txt 
+       -r{toxinidir}/test-requirements.txt
        -r{toxinidir}/requirements.txt
 
 [testenv:unit]
 basepython = python3.6
 commands =
     env TEST_OSPROFILER=1 stestr run 'networking_nsxv3.tests.unit'
-
-[testenv:u1]
-basepython = python3.6
-commands =
-    env TEST_OSPROFILER=1 stestr run 'test_double_creation_of_default_group'
 
 [testenv:coverage]
 setenv =


### PR DESCRIPTION
If we try to create a group, which already exists, the api
throws an exception, but that isn't a problem for us, so
we can just continue as if we have created it