### PR TITLE
For sync loop, ignore "maybe" orphaned groups (security group members),

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_mgmt.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_mgmt.py
@@ -745,9 +745,9 @@ class Provider(abs.Provider):
         outdated = k1.difference(k2)
         orphaned = k2.difference(k1)
 
-        # Remove Member orphans still in use
+        # Don't count orphans for members, we don't know yet if they are really orphaned
         if resource_type == Provider.SG_MEMBERS:
-            orphaned = orphaned.difference(self._metadata.get(Provider.SG_RULES).meta.keys())
+            orphaned = set()
 
         # Remove Ports not yet exceeding delete timeout
         if resource_type == Provider.PORT:

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
@@ -76,7 +76,7 @@ class AgentRealizer(object):
             legacy_sgm_outdated, _ = l.outdated(l.SG_MEMBERS, dict())
 
             # There is not way to revision group members but can 'age' them
-            sgm_outdated, _ = p.outdated(p.SG_MEMBERS, {sg: 0 for sg in sg_meta})
+            sgm_outdated, sgm_maybe_orphans = p.outdated(p.SG_MEMBERS, {sg: 0 for sg in sg_meta})
             LOG.info("Inventory metadata have been refreshed.")
 
             if dryrun:
@@ -102,6 +102,7 @@ class AgentRealizer(object):
             if _slice <= 0:
                 return
 
+            # sgm_outdated only includes missing objects, orphans are removed by ageing
             outdated = list(itertools.islice(sgm_outdated, _slice))
             _slice -= len(outdated)
             LOG.info("Realizing %s/%s resources of Type:Security Group Members",
@@ -120,7 +121,7 @@ class AgentRealizer(object):
 
             current = p.age(p.PORT, port_current)
             current += p.age(p.SG_RULES, sgr_current)
-            current += p.age(p.SG_MEMBERS, sgm_outdated)
+            current += p.age(p.SG_MEMBERS, sgm_maybe_orphans)
             current += p.age(p.QOS, qos_current)
 
             # Sanitize when there are no elements or the eldest age > current age


### PR DESCRIPTION
since they could lead to a slice-starvation, because the sync-loop cannot
ensure that they are really orphaned.

instead, only realize groups that we now need to exist at least,
and let the "ageing" take care of the rest.