### PR TITLE
has_security_group_used_by_host should evaluate true if security grou…

### DIFF
--- a/networking_nsxv3/db/db.py
+++ b/networking_nsxv3/db/db.py
@@ -349,7 +349,10 @@ def get_remote_security_groups_for_host(context, host, limit, cursor):
 
 def has_security_group_used_by_host(context, host, security_group_id):
     return context.session.query(
-        sg_db.SecurityGroupRule.remote_group_id,
+        sg_db.SecurityGroup.id,
+    ).join(
+        sg_db.SecurityGroupRule,
+        sg_db.SecurityGroupRule.security_group_id == sg_db.SecurityGroup.id
     ).join(
         sg_db.SecurityGroupPortBinding,
         sg_db.SecurityGroupPortBinding.security_group_id == sg_db.SecurityGroupRule.security_group_id
@@ -358,7 +361,7 @@ def has_security_group_used_by_host(context, host, security_group_id):
         PortBindingLevel.port_id == sg_db.SecurityGroupPortBinding.port_id
     ).filter(
         (sg_db.SecurityGroupRule.remote_group_id == security_group_id) | \
-        (sg_db.SecurityGroupRule.security_group_id == security_group_id),
+        (sg_db.SecurityGroup.id == security_group_id),
         PortBindingLevel.host == host,
         PortBindingLevel.driver == nsxv3_constants.NSXV3,
     ).limit(1).first() is not None


### PR DESCRIPTION
…p has no rules

The query didn't suceeded if all condition were true, but the group had no rules at all.
This fixes it and successfully realizes security groups with their depended groups.