### PR TITLE
Remove Ovs-Hybrid-Plug flag

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/driver.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/driver.py
@@ -50,7 +50,6 @@ class VMwareNSXv3MechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         self.vif_type = portbindings.VIF_TYPE_OVS
         self.vif_details = {
             portbindings.CAP_PORT_FILTER: sg_enabled,
-            portbindings.OVS_HYBRID_PLUG: sg_enabled,
             portbindings.VIF_DETAILS_CONNECTIVITY:
                 portbindings.CONNECTIVITY_L2
         }


### PR DESCRIPTION
The flag is for custom behaviour specific to
open-v-switch, which we do not want/need to trigger,
so we rather remove it.

Specifically it causes neutron to send a network-vif-plugged event
during live migration after port profile is updated with "migrating-to:"

That in turn causes a the port to be shut-down for a short period,
which we rather want to avoid.