### PR TITLE
Fixes: Trunk MP-to-Policy migrations

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
@@ -30,6 +30,10 @@ def is_revision_error(response):
     return response.status_code == 412 and re.search("Fetch the latest copy of the object and retry", response.text)
 
 
+def is_child_deps_error(response):
+    return response.status_code == 400 and re.search("cannot be deleted as either it has children or it is being referenced by other objects path", response.text)
+
+
 class Singleton(type):
     _instances = {}
 
@@ -77,6 +81,9 @@ class RetryPolicy(object):
                         return response
 
                     if is_revision_error(response):
+                        return response
+
+                    if is_child_deps_error(response):
                         return response
 
                     if response.status_code in [401, 403]:

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider.py
@@ -128,7 +128,7 @@ class Meta(object):
     def reset(self):
         self.meta = dict()
 
-    def keys(self) -> dict:
+    def keys(self) -> List[str]:
         keys = self.meta.keys()
         if self.meta_transaction:
             keys += self.meta_transaction.keys()

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
@@ -667,12 +667,12 @@ class Provider(base.Provider):
 
         if parent_port_id:
             # Child port always created internally
-            parent_port = self.get_port(parent_port_id)
-            if parent_port:
-                provider_port["parent_id"] = parent_port[0].id
+            parent_meta, nsx_port = self.get_port(parent_port_id)
+            if parent_meta:
+                provider_port["parent_id"] = parent_meta.id
                 provider_port["id"] = sg_meta.id
             else:
-                LOG.warning("Not found. Parent Segment Port:%s for Child Port:%s", parent_port_id, port_id)
+                LOG.warning("Not found. Parent Segment Port:%s for Child Port:%s.", parent_port_id, port_id)
                 return
         else:
             if sg_meta:
@@ -724,7 +724,9 @@ class Provider(base.Provider):
         port = self.client.get_unique(path=API.SEARCH_QUERY, params={"query": API.SEARCH_Q_SEG_PORT.format(os_id)})
         if port and not port.get("id").startswith(API.POLICY_MNG_PREFIX):
             return self.metadata_update(Provider.SEGM_PORT, port), port
-        return None
+        elif port:
+            return None, port
+        return None, None
 
     def get_port_meta_by_ids(self, port_ids: Set[str]) -> Set[PolicyResourceMeta]:
         segment_ports = set()

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
@@ -124,6 +124,8 @@ class AgentRealizer(object):
                 seg_port_outdated, seg_port_current, port_outdated, port_current)
             seg_qos_outdated, seg_qos_current, qos_outdated = self._filter_plcy_mngr_objs(
                 seg_qos_outdated, seg_qos_current, qos_outdated, qos_current)
+            qos_outdated, qos_current, seg_qos_outdated = self._filter_plcy_mngr_objs(
+                qos_outdated, qos_current, seg_qos_outdated, seg_qos_current)
 
             # There is not way to revision group members but can 'age' them
             sgm_outdated, sgm_maybe_orphans = pp.outdated(pp.SG_MEMBERS, {sg: 0 for sg in sg_meta})
@@ -437,7 +439,7 @@ class AgentRealizer(object):
         nsxt_max = 29
         tag_trigger = cfg.CONF.AGENT.migration_tag_count_trigger
         tag_max = cfg.CONF.AGENT.migration_tag_count_max
-        tag_count = len(port.get("tags"))
+        tag_count = len(port.get("tags")) if port.get("tags") else 0
         if not force:
             if tag_trigger <= tag_count <= tag_max:
                 LOG.info(f"Migration criteria met. Tags: {tag_count} (trigger: {tag_trigger}, max: {tag_max})")

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
@@ -472,7 +472,7 @@ class AgentRealizer(object):
         not_migrated_sys_owned, not_migrated_not_sys_owned = [], []
 
         if self.force_mp_to_policy and self.migr_provider:
-            mgmt_profile_ids = [p.get("id") for p in mgmt_sw_profiles if p]
+            mgmt_profile_ids = [p.get("id") for p in mgmt_sw_profiles if p and p.get("_create_user") != "nsx_policy"]
             plcy_profile_ids = [p.get("id") for p in policy_sw_profiles if p]
 
             not_migrated_ids = [p_id for p_id in mgmt_profile_ids if p_id not in plcy_profile_ids]

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
@@ -382,7 +382,7 @@ class AgentRealizer(object):
 
         mp.qos_realize(os_qos, delete)
         if self.force_mp_to_policy and not delete:
-            self._get_notmigrated_switching_profiles()
+            self._promote_switching_profiles()
 
     def _port_realize(self, os_port: dict, delete: bool = False):
         pp = self.plcy_provider

--- a/networking_nsxv3/tests/unit/realization/test_realization.py
+++ b/networking_nsxv3/tests/unit/realization/test_realization.py
@@ -15,7 +15,6 @@ LOG: logging.KeywordArgumentAdapter = logging.getLogger(__name__)
 
 
 # TODO - replace static wait/sleep with active polling
-# TODO - split into more granual functional tests
 
 def set_logging_levels():
     cfg.CONF.set_override("default_log_levels", [


### PR DESCRIPTION
 Issues found during the functional testing of the MP-to-Policy Migration:

1. There was a missing port_id for the Child SegmentPorts, which resulted in faulty synchronization.
2. The deletion of the SegmentPorts via the Policy API was not working as expected.
3. When a Child Port is migrated, its Parent Trunk is not and that led to unsuccessful child update

Fixes:
1. Added the missing ID.
2. Before deletion of each SegmentPort, first get the full object from NSX-T.
3. Force the migration of the parent port before realizing the child port.
4. Migration of Ports with QoS Policy fixes 