### PR TITLE
Fix trunk RPC handlers

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/driver.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/driver.py
@@ -24,14 +24,6 @@ from neutron.services.logapi.drivers import manager
 LOG = log.getLogger(__name__)
 
 
-class TrunkPayload(events.EventPayload):
-    def __init__(self, context, trunk_id, current_trunk, subports):
-        super(TrunkPayload, self).__init__(context)
-        self.current_trunk = current_trunk
-        self.trunk_id = trunk_id
-        self.subports = subports
-
-
 class VMwareNSXv3MechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
     """Attach to networks using vmware nsx-t agent.
 
@@ -198,7 +190,11 @@ class VMwareNSXv3MechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                         segmentation_type=p['segmentation_type'])
                 for p in sub_ports]
         trunk = trunk_objects.Trunk.get_object(context=admin_ctx, id=truk_id)
-        payload = TrunkPayload(admin_ctx, trunk.id, trunk, subports)
+        payload = events.DBEventPayload(admin_ctx, resource_id=trunk.id,
+                                        states=(trunk, trunk,),
+                                        metadata={
+                                            'subports': subports
+                                        })
 
         if delete:
             registry.publish(resources.SUBPORTS, events.AFTER_DELETE, self, payload=payload)

--- a/networking_nsxv3/services/trunk/drivers/nsxv3/trunk.py
+++ b/networking_nsxv3/services/trunk/drivers/nsxv3/trunk.py
@@ -68,33 +68,33 @@ class NSXv3TrunkDriver(base.DriverBase):
         return ctx, parent
 
     def trunk_create(self, resource, event, trunk_plugin, payload):
-        ctx, parent = self._get_context_and_parent_port(payload.current_trunk.port_id)
+        ctx, parent = self._get_context_and_parent_port(payload.states[0].port_id)
         if not parent:
             return
 
         LOG.info("Trunk create called, resource %s payload %s trunk id %s",
-                 resource, payload, payload.trunk_id)
-        self._bind_subports(ctx, parent, payload.current_trunk, payload.current_trunk.sub_ports)
-        payload.current_trunk.update(status=trunk_consts.TRUNK_ACTIVE_STATUS)
+                 resource, payload, payload.resource_id)
+        self._bind_subports(ctx, parent, payload.states[0], payload.states[0].sub_ports)
+        payload.states[0].update(status=trunk_consts.TRUNK_ACTIVE_STATUS)
 
     def trunk_delete(self, resource, event, trunk_plugin, payload):
-        ctx, parent = self._get_context_and_parent_port(payload.original_trunk.port_id)
+        ctx, parent = self._get_context_and_parent_port(payload.states[0].port_id)
         if not parent:
             return
 
-        LOG.info("Trunk %s delete called", payload.trunk_id)
-        self._bind_subports(ctx, parent, payload.original_trunk, payload.original_trunk.sub_ports, delete=True)
+        LOG.info("Trunk %s delete called", payload.resource_id)
+        self._bind_subports(ctx, parent, payload.states[0], payload.states[0].sub_ports, delete=True)
 
     def subport_create(self, resource, event, trunk_plugin, payload):
-        ctx, parent = self._get_context_and_parent_port(payload.current_trunk.port_id)
+        ctx, parent = self._get_context_and_parent_port(payload.states[0].port_id)
         if not parent:
             return
 
-        self._bind_subports(ctx, parent, payload.current_trunk, payload.subports)
+        self._bind_subports(ctx, parent, payload.states[0], payload.metadata['subports'])
 
     def subport_delete(self, resource, event, trunk_plugin, payload):
-        ctx, parent = self._get_context_and_parent_port(payload.current_trunk.port_id)
-        self._bind_subports(ctx or payload.context, parent, payload.current_trunk, payload.subports, delete=True)
+        ctx, parent = self._get_context_and_parent_port(payload.states[0].port_id)
+        self._bind_subports(ctx or payload.context, parent, payload.states[0], payload.metadata['subports'], delete=True)
 
     def _bind_subports(self, ctx, parent, trunk, subports, delete=False):
         for subport in subports:

--- a/networking_nsxv3/tests/unit/trunk/test_service_trunk.py
+++ b/networking_nsxv3/tests/unit/trunk/test_service_trunk.py
@@ -222,16 +222,17 @@ class TestNSXv3TrunkDriver(base.BaseTestCase):
                 # Prepare parameters
                 par_resource = 'MyResource'
                 par_payload = SimpleObject()
-                par_payload.current_trunk = SimpleObject()
-                par_payload.current_trunk.sub_ports = 'MyCurrentTrunkSubPorts'
+                par_payload.states = []
+                par_payload.states[0] = SimpleObject()
+                par_payload.states[0].sub_ports = 'MyCurrentTrunkSubPorts'
                 par_payload.trunk_id = 'MyTrunkID'
-                par_payload.current_trunk.update = mocked_current_trunk_update
+                par_payload.states[0].update = mocked_current_trunk_update
 
                 # Initialize/Prepare the call tracker for test call number 1
                 self.call_tracker.init_track('trunk_create')
 
                 # Make test call number 1
-                par_payload.current_trunk.port_id = None
+                par_payload.states[0].port_id = None
                 nsx_trunc_driver.trunk_create(par_resource, None, None, par_payload)
 
                 # No activity is expected
@@ -241,7 +242,7 @@ class TestNSXv3TrunkDriver(base.BaseTestCase):
                 self.call_tracker.init_track('trunk_create')
 
                 # Make test call number 2
-                par_payload.current_trunk.port_id = 'MyCurrentTrunkPortID'
+                par_payload.states[0].port_id = 'MyCurrentTrunkPortID'
                 nsx_trunc_driver.trunk_create(par_resource, None, None, par_payload)
 
                 # Activity is expected
@@ -251,10 +252,10 @@ class TestNSXv3TrunkDriver(base.BaseTestCase):
                         'trunk_create',
                         [
                             'mocked__bind_subports'
-                            + ':ctx:' + 'context_for_' + str(par_payload.current_trunk.port_id)
-                            + ':parent:' + 'parent_for_' + str(par_payload.current_trunk.port_id)
-                            + ':trunk:' + str(par_payload.current_trunk)
-                            + ':subports:' + str(par_payload.current_trunk.sub_ports)
+                            + ':ctx:' + 'context_for_' + str(par_payload.states[0].port_id)
+                            + ':parent:' + 'parent_for_' + str(par_payload.states[0].port_id)
+                            + ':trunk:' + str(par_payload.states[0])
+                            + ':subports:' + str(par_payload.states[0].sub_ports)
                             + ':delete:' + str(False),
                             'mocked_current_trunk_update:status:' + trunk_consts.TRUNK_ACTIVE_STATUS
                         ]
@@ -288,15 +289,16 @@ class TestNSXv3TrunkDriver(base.BaseTestCase):
                 # Prepare parameters
                 par_resource = 'MyResource'
                 par_payload = SimpleObject()
-                par_payload.original_trunk = SimpleObject()
-                par_payload.original_trunk.sub_ports = 'MyOriginalTrunkSubPorts'
+                par_payload.states = []
+                par_payload.states[0] = SimpleObject()
+                par_payload.states[0].sub_ports = 'MyOriginalTrunkSubPorts'
                 par_payload.trunk_id = 'MyTrunkID'
 
                 # Initialize/Prepare the call tracker for test call number 1
                 self.call_tracker.init_track('trunk_delete')
 
                 # Make test call number 1
-                par_payload.original_trunk.port_id = None
+                par_payload.states[0].port_id = None
                 nsx_trunc_driver.trunk_delete(par_resource, None, None, par_payload)
 
                 # No activity is expected
@@ -306,7 +308,7 @@ class TestNSXv3TrunkDriver(base.BaseTestCase):
                 self.call_tracker.init_track('trunk_delete')
 
                 # Make test call number 2
-                par_payload.original_trunk.port_id = 'MyCurrentTrunkPortID'
+                par_payload.states[0].port_id = 'MyCurrentTrunkPortID'
                 nsx_trunc_driver.trunk_delete(par_resource, None, None, par_payload)
 
                 # Activity is expected
@@ -316,10 +318,10 @@ class TestNSXv3TrunkDriver(base.BaseTestCase):
                         'trunk_delete',
                         [
                             'mocked__bind_subports'
-                            + ':ctx:' + 'context_for_' + str(par_payload.original_trunk.port_id)
-                            + ':parent:' + 'parent_for_' + str(par_payload.original_trunk.port_id)
-                            + ':trunk:' + str(par_payload.original_trunk)
-                            + ':subports:' + str(par_payload.original_trunk.sub_ports)
+                            + ':ctx:' + 'context_for_' + str(par_payload.states[0].port_id)
+                            + ':parent:' + 'parent_for_' + str(par_payload.states[0].port_id)
+                            + ':trunk:' + str(par_payload.states[0])
+                            + ':subports:' + str(par_payload.states[0].sub_ports)
                             + ':delete:' + str(True)
                         ]
                     ),
@@ -352,7 +354,8 @@ class TestNSXv3TrunkDriver(base.BaseTestCase):
                 # Prepare parameters
                 par_resource = 'MyResource'
                 par_payload = SimpleObject()
-                par_payload.current_trunk = SimpleObject()
+                par_payload.states = []
+                par_payload.states[0] = SimpleObject()
                 par_payload.subports = 'MyTrunkSubPorts'
                 par_payload.trunk_id = 'MyTrunkID'
 
@@ -360,7 +363,7 @@ class TestNSXv3TrunkDriver(base.BaseTestCase):
                 self.call_tracker.init_track('subport_create')
 
                 # Make test call number 1
-                par_payload.current_trunk.port_id = None
+                par_payload.states[0].port_id = None
                 nsx_trunc_driver.subport_create(par_resource, None, None, par_payload)
 
                 # No activity is expected
@@ -370,7 +373,7 @@ class TestNSXv3TrunkDriver(base.BaseTestCase):
                 self.call_tracker.init_track('subport_create')
 
                 # Make test call number 2
-                par_payload.current_trunk.port_id = 'MyCurrentTrunkPortID'
+                par_payload.states[0].port_id = 'MyCurrentTrunkPortID'
                 nsx_trunc_driver.subport_create(par_resource, None, None, par_payload)
 
                 # Activity is expected
@@ -380,9 +383,9 @@ class TestNSXv3TrunkDriver(base.BaseTestCase):
                         'subport_create',
                         [
                             'mocked__bind_subports'
-                            + ':ctx:' + 'context_for_' + str(par_payload.current_trunk.port_id)
-                            + ':parent:' + 'parent_for_' + str(par_payload.current_trunk.port_id)
-                            + ':trunk:' + str(par_payload.current_trunk)
+                            + ':ctx:' + 'context_for_' + str(par_payload.states[0].port_id)
+                            + ':parent:' + 'parent_for_' + str(par_payload.states[0].port_id)
+                            + ':trunk:' + str(par_payload.states[0])
                             + ':subports:' + str(par_payload.subports)
                             + ':delete:' + str(False)
                         ]
@@ -416,7 +419,8 @@ class TestNSXv3TrunkDriver(base.BaseTestCase):
                 # Prepare parameters
                 par_resource = 'MyResource'
                 par_payload = SimpleObject()
-                par_payload.current_trunk = SimpleObject()
+                par_payload.states = []
+                par_payload.states[0] = SimpleObject()
                 par_payload.subports = 'MyTrunkSubPorts'
                 par_payload.trunk_id = 'MyTrunkID'
                 par_payload.context = None
@@ -425,7 +429,7 @@ class TestNSXv3TrunkDriver(base.BaseTestCase):
                 self.call_tracker.init_track('subport_delete')
 
                 # Make test call number 1
-                par_payload.current_trunk.port_id = None
+                par_payload.states[0].port_id = None
                 nsx_trunc_driver.subport_delete(par_resource, None, None, par_payload)
 
                 # Activity is expected
@@ -435,7 +439,7 @@ class TestNSXv3TrunkDriver(base.BaseTestCase):
                 self.call_tracker.init_track('subport_delete')
 
                 # Make test call number 2
-                par_payload.current_trunk.port_id = 'MyCurrentTrunkPortID'
+                par_payload.states[0].port_id = 'MyCurrentTrunkPortID'
                 nsx_trunc_driver.subport_delete(par_resource, None, None, par_payload)
 
                 # Activity is expected
@@ -445,9 +449,9 @@ class TestNSXv3TrunkDriver(base.BaseTestCase):
                         'subport_delete',
                         [
                             'mocked__bind_subports'
-                            + ':ctx:' + 'context_for_' + str(par_payload.current_trunk.port_id)
-                            + ':parent:' + 'parent_for_' + str(par_payload.current_trunk.port_id)
-                            + ':trunk:' + str(par_payload.current_trunk)
+                            + ':ctx:' + 'context_for_' + str(par_payload.states[0].port_id)
+                            + ':parent:' + 'parent_for_' + str(par_payload.states[0].port_id)
+                            + ':trunk:' + str(par_payload.states[0])
                             + ':subports:' + str(par_payload.subports)
                             + ':delete:' + str(True)
                         ]


### PR DESCRIPTION
In these two commits:
https://github.com/sapcc/neutron/commit/129b823a8b610284ff95cc5e7b2f7b6ed3540172
https://github.com/sapcc/neutron/commit/69ef824069c3b1435a50c0d937ad45a23ff07c1b
the RPC was changed to use DBEventPayload from the neutron library instead of custom objects.

The new payload has different formats for different event types, here documentation: https://docs.openstack.org/neutron-lib/latest/contributor/callbacks.html#event-objects-dbeventpayload

In this PR we change our driver to have the correct handlers for RPC events coming from Neutron server.