### PR TITLE
Improve sql performance

### DIFF
--- a/networking_nsxv3/db/db.py
+++ b/networking_nsxv3/db/db.py
@@ -27,6 +27,7 @@ def get_ports_with_revisions(context, host, limit, cursor):
         Port.standard_attr_id.asc()
     ).filter(
         StandardAttribute.id == Port.standard_attr_id,
+        StandardAttribute.resource_type == 'ports',
         PortBindingLevel.host == host,
         PortBindingLevel.driver == nsxv3_constants.NSXV3,
         Port.standard_attr_id > cursor,
@@ -50,6 +51,7 @@ def get_qos_policies_with_revisions(context, host, limit, cursor):
         QosPolicy.standard_attr_id.asc()
     ).filter(
         StandardAttribute.id == QosPolicy.standard_attr_id,
+        StandardAttribute.resource_type == 'qos_policies',
         PortBindingLevel.host == host,
         PortBindingLevel.driver == nsxv3_constants.NSXV3,
         QosPolicy.standard_attr_id > cursor
@@ -72,11 +74,12 @@ def get_security_groups_with_revisions(context, host, limit, cursor):
         sg_db.SecurityGroup.standard_attr_id.asc()
     ).filter(
         StandardAttribute.id == sg_db.SecurityGroup.standard_attr_id,
+        StandardAttribute.resource_type == 'securitygroups',
         PortBindingLevel.host == host,
         PortBindingLevel.level == 1,
         PortBindingLevel.driver == nsxv3_constants.NSXV3,
         sg_db.SecurityGroup.standard_attr_id > cursor
-    ).limit(
+    ).distinct().limit(
         limit
     ).all()
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-neutron>=16.3.2,<17 # Apache-2.0
+neutron>=20.0.0, <21.0.0 # Apache-2.0
 hacking!=0.13.0,<0.14,>=0.12.0 # Apache-2.0
 coverage!=4.4,>=4.0 # Apache-2.0
 ddt>=1.0.1 # MIT

--- a/tox.ini
+++ b/tox.ini
@@ -30,27 +30,27 @@ setenv = VIRTUAL_ENV={envdir}
          NSXV3_LOGIN_PASSWORD={env:NSXV3_LOGIN_PASSWORD:}
          NSXV3_TRANSPORT_ZONE_NAME={env:NSXV3_TRANSPORT_ZONE_NAME:}
 
-deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/ussuri}
+deps = -c{env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/yoga-m3/upper-constraints.txt}
        -r{toxinidir}/test-requirements.txt
        -r{toxinidir}/requirements.txt
 
 [testenv:unit]
-basepython = python3.6
+basepython = python3.8
 commands =
     env TEST_OSPROFILER=1 stestr run 'networking_nsxv3.tests.unit'
 
 [testenv:migration]
-basepython = python3.6
+basepython = python3.8
 commands =
     env TEST_OSPROFILER=1 stestr run 'networking_nsxv3.tests.unit.test_mp_to_policy'
 
 [testenv:realization]
-basepython = python3.6
+basepython = python3,8
 commands =
     env TEST_OSPROFILER=1 stestr run 'networking_nsxv3.tests.unit.realization'
 
 [testenv:db]
-basepython = python3.6
+basepython = python3.8
 commands =
     env TEST_OSPROFILER=1 stestr run 'networking_nsxv3.tests.unit.db'
 


### PR DESCRIPTION
Checking the slow performance log of our neutron database revealed that 20-30% of the slow queries go back to nsxt queries fetching information about objects ports, security_groups and qos enriching them
    with revison information. Every nsxt agent runs those queries reguarly to determine orphand or outdated ports, security groups, qos_policies.
    Performance could be improved by applying a filter for the standardattribute table containg the revision information. Since the table contains siginficantlly more entries than the other tables (million vs. thousand entries), the number entires joined with the object information dropped.
    For all queries pagination has been implemented. Since the security_groups query did not handle duplicate values (due to the m-to-n relathionship between sg and ports), agents with a high number of sgs and ports, have been found triggering the query executiion multiple times
    until all data are fetched.
