### PR TITLE
Persisting the result of successful MP-to-Policy migration

### DIFF
--- a/networking_nsxv3/common/constants.py
+++ b/networking_nsxv3/common/constants.py
@@ -25,9 +25,9 @@ NSXV3_LOGGING_ENABLED = "enabled"
 NSXV3_DEFAULT_POLICY_ID = "DefaultML2Policy"
 NSXV3_DEFAULT_LOGGING_ID = "DefaultLoggingRule"
 
-NSXV3_MIGRATION_SCOPE = "vswitch_migration_target"
-NSXV3_MIGRATION_TAG_DVS = "dvs"
-NSXV3_MIGRATION_TAG_NVDS = "nvds"
+NSXV3_MP_MIGRATION_SCOPE = "mp2policy_migr_status"
+NSXV3_HOSTSWITCH_MIGRATION_SCOPE = "hostswitch_migr_status"
+NSXV3_MIGRATION_SUCCESS_TAG = "success"
 
 NSXV3_CAPABILITY_TCP_STRICT = "capability_tcp_strict"
 # If TCP strict is enabled on a section and a packet matches rule in it,

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider.py
@@ -441,5 +441,5 @@ class MigrationTracker(object):
         with LockManager.get_lock(self.mutex):
             return self._migration_in_progress
 
-    def store_migration_result(self, migration_scope: str, migration_result: str):
+    def persist_migration_status(self, migration_scope: str, migration_result: str):
         self.provider.tag_transport_zone(scope=migration_scope, tag=migration_result)

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_mgmt.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_mgmt.py
@@ -1,3 +1,6 @@
+import eventlet
+eventlet.monkey_patch()
+
 import copy
 import time
 from typing import List, Tuple
@@ -439,11 +442,11 @@ class Provider(base.Provider):
 
         self._setup_default_switching_profiles()
 
-    def _load_zone(self):
+    def _load_zones(self):
         LOG.info("Looking for TransportZone with name %s.", self.zone_name)
         for zone in self.client.get_all(path="/api/v1/transport-zones"):
             if zone.get("display_name") == self.zone_name:
-                return zone.get("id")
+                return zone.get("id"), []
 
     def _setup_default_switching_profiles(self):
         sg = self.payload.spoofguard()
@@ -852,3 +855,6 @@ class Provider(base.Provider):
                     break
 
         return sanitize
+
+    def tag_transport_zone(self, scope, tag):
+        raise NotImplementedError("Unsupported operation for NSX Manager Provider")

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
@@ -1,25 +1,23 @@
 import eventlet
 eventlet.monkey_patch()
 
-import ipaddress
-from networking_nsxv3.prometheus import exporter
-from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.constants_nsx import *
-from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import provider as base
-from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import provider_nsx_mgmt
-from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.client_nsx import Client
-from networking_nsxv3.common.locking import LockManager
-from networking_nsxv3.common.constants import *
-from oslo_utils import excutils
-from oslo_log import log as logging
-from oslo_config import cfg
-import functools
-import json
-import re
-from requests.exceptions import HTTPError
-import uuid
-import functools
 from typing import Callable, Dict, List, Set
-
+import uuid
+from requests.exceptions import HTTPError
+import re
+import json
+import functools
+from oslo_config import cfg
+from oslo_log import log as logging
+from oslo_utils import excutils
+from networking_nsxv3.common.constants import *
+from networking_nsxv3.common.locking import LockManager
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.client_nsx import Client
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import provider_nsx_mgmt
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import provider as base
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.constants_nsx import *
+from networking_nsxv3.prometheus import exporter
+import ipaddress
 
 
 LOG: logging.KeywordArgumentAdapter = logging.getLogger(__name__)
@@ -98,6 +96,7 @@ class API(provider_nsx_mgmt.API):
 
     STATUS = INFRA + "/realized-state/status"
     TRANSPORT_ZONES_PATH = "/infra/sites/default/enforcement-points/default/transport-zones/{}"
+    TRANSPORT_ZONE = POLICY_BASE + TRANSPORT_ZONES_PATH
 
     POLICY_MNG_PREFIX = "default:"
 
@@ -448,11 +447,24 @@ class Provider(base.Provider):
             self._ensure_default_l3_policy()
         self._setup_default_app_drop_logged_section()
 
-    def _load_zone(self):
+    def _get_tz(self) -> dict or None:
+        for tz in self.client.get_all(path=API.SEARCH_QUERY, params={"query": API.SEARCH_Q_TRANSPORT_ZONES.format(self.zone_name)}):
+            if tz.get("display_name") == self.zone_name:
+                return tz
+        return None
+
+    def _load_zones(self):
         LOG.info("Looking for TransportZone with name %s.", self.zone_name)
-        for zone in self.client.get_all(path=API.SEARCH_QUERY, params={"query": API.SEARCH_Q_TRANSPORT_ZONES.format(self.zone_name)}):
-            if zone.get("display_name") == self.zone_name:
-                return zone.get("id")
+
+        zone_id = None
+        zone_tags = []
+
+        tz = self._get_tz()
+        if tz:
+            zone_id = tz.get("id")
+            zone_tags = tz.get("tags", [])
+
+        return zone_id, zone_tags
 
     def _ensure_default_l3_policy(self):
         res = self.client.get(path=API.POLICY.format(NSXV3_DEFAULT_L3_SECTION))
@@ -754,7 +766,8 @@ class Provider(base.Provider):
                 sg_meta = self.metadata(self.SG_MEMBERS, sg_id)
                 if not sg_meta:
                     # Realize the Security Group if it does not exist with empty members
-                    sg_meta = self.sg_members_realize({"id": sg_id, "cidrs": [], "revision_number": 0, "member_paths": []})
+                    sg_meta = self.sg_members_realize(
+                        {"id": sg_id, "cidrs": [], "revision_number": 0, "member_paths": []})
                 if not port_meta.path:
                     raise RuntimeError(f"Not found path in Metadata for port: {port_meta.real_id}")
                 if port_meta.path not in sg_meta.sg_members:
@@ -997,3 +1010,17 @@ class Provider(base.Provider):
     def update_policy_logging(self, log_obj):
         LOG.debug(f"PROVIDER: update_policy_logging")
         return self.set_policy_logging(log_obj, log_obj['enabled'])
+
+    def tag_transport_zone(self, scope, tag):
+        tz = self._get_tz()
+        tags = tz.get("tags", [])
+        updated_tag_list = []
+
+        if len(tags) < 1:
+            updated_tag_list = [{"scope": scope, "tag": tag}]
+        else:
+            updated_tag_list = list([t for t in tags if t.get("scope") != scope])
+            updated_tag_list.append({"scope": scope, "tag": tag})
+
+        tz["tags"] = updated_tag_list
+        self.client.put(path=API.TRANSPORT_ZONE.format(tz.get("id")), data=tz)


### PR DESCRIPTION
Persisting the result of a successful MP-to-Policy in the Transport Zone tag, so on restart the agent:

- will not try to conduct a migration again
- will use only Policy API