### PR TITLE
Unpersist MP-TO-POLICY migration before running the brownfield tests

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider.py
@@ -5,6 +5,7 @@ from oslo_config import cfg
 from oslo_log import log as logging
 from typing import Callable, Dict, List, Set, Tuple
 
+from networking_nsxv3.common.constants import NSXV3_MP_MIGRATION_SCOPE
 from networking_nsxv3.common.locking import LockManager
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.client_nsx import Client
 
@@ -443,3 +444,6 @@ class MigrationTracker(object):
 
     def persist_migration_status(self, migration_scope: str, migration_result: str):
         self.provider.tag_transport_zone(scope=migration_scope, tag=migration_result)
+
+    def unpersist_migration_status(self):
+        self.provider.tag_transport_zone(scope=NSXV3_MP_MIGRATION_SCOPE, tag="run-migration-again")

--- a/networking_nsxv3/tests/functional/base_nsxv3_api.py
+++ b/networking_nsxv3/tests/functional/base_nsxv3_api.py
@@ -4,7 +4,7 @@ eventlet.monkey_patch()
 from networking_nsxv3.tests.environment import Environment
 from oslo_log import log as logging
 from oslo_config import cfg
-from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import client_nsx, provider_nsx_mgmt, provider_nsx_policy
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import client_nsx, provider_nsx_mgmt, provider_nsx_policy, provider
 from networking_nsxv3.tests.datasets import coverage
 import copy
 import functools
@@ -151,6 +151,12 @@ class BaseNsxTest(base.BaseTestCase):
                 p = env.manager.realizer.mngr_provider
                 if type != p.NETWORK and type != p.SG_RULES_REMOTE_PREFIX:
                     self.assertEquals(expected=dict(), observed=meta["meta"])
+
+    @classmethod
+    def unpersist_migration_status(cls):
+        LOG.info(f"Remove Tags persisting mp-to--policy migration")
+        migration_tracker = provider.MigrationTracker(provider_nsx_policy.Provider())
+        migration_tracker.unpersist_migration_status()
 
     @classmethod
     def enable_nsxtside_m2policy_migration(cls):

--- a/networking_nsxv3/tests/functional/mp2policy/test_brownfield_hapy_path.py
+++ b/networking_nsxv3/tests/functional/mp2policy/test_brownfield_hapy_path.py
@@ -28,6 +28,7 @@ class TestMp2PolicyMigr(BaseNsxTest):
             cls.skipTest(
                 cls, f"Migration Functional Tests skipped. Migration is NOT supported for NSX-T < {MP2POLICY_NSX_MIN_VERSION}")
         cls.clean_all_from_nsx()
+        cls.unpersist_migration_status()
         cls.enable_nsxtside_m2policy_migration()
 
         LOG.info(f"Activate migration on driver side")

--- a/networking_nsxv3/tests/functional/mp2policy/test_brownfield_unhapy_path.py
+++ b/networking_nsxv3/tests/functional/mp2policy/test_brownfield_unhapy_path.py
@@ -29,6 +29,7 @@ class TestMp2PolicyMigr(BaseNsxTest):
             cls.skipTest(
                 cls, f"Migration Functional Tests skipped. Migration is NOT supported for NSX-T < {MP2POLICY_NSX_MIN_VERSION}")
         cls.clean_all_from_nsx()
+        cls.unpersist_migration_status()
         cls.enable_nsxtside_m2policy_migration()
 
         LOG.info(f"Activate migration on driver side")


### PR DESCRIPTION
To avoid running the mp-to-policy migration all over again, once a nsxv3 agent get restarted, a tag was introduced indicating wether the migration was already executed succesfully. As consequence the brownfield tests work only once because on nsxt side a tag is set indicating the succesfull migration. To overcome this, the migration tag needs to be removed before running a migration