### PR TITLE
Safely fetch path information for sentry fingerprinting

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
@@ -111,14 +111,14 @@ class RetryPolicy(object):
                     # Retry for Migration coordinator backend is busy. Please try again after some time.
                     if not is_atomic_request_error(response) or not is_migration_bussy_error(response):
                         # skip retry on the ramaining NSX errors
-                        sentry_extra["fingerprint"] = [RetryPolicy._create_sentry_fingerprint(kwargs["path"]),
+                        sentry_extra["fingerprint"] = [RetryPolicy._create_sentry_fingerprint(kwargs.get("path", '')),
                                                        response.request.method]
                         LOG.error("Request={} Response={}".format(request_info, last_err), extra=sentry_extra)
                         break
                 except (HTTPError, ConnectionError, ConnectTimeout) as err:
                     last_err = err
                     m = response.request.method if response else "UNKNOWN"
-                    sentry_extra["fingerprint"] = [RetryPolicy._create_sentry_fingerprint(kwargs["path"]), m]
+                    sentry_extra["fingerprint"] = [RetryPolicy._create_sentry_fingerprint(kwargs.get("path", '')), m]
                     LOG.error("Request={} Response={}".format(request_info, last_err), extra=sentry_extra)
 
                 msg = pattern.format(attempt, until, pause, method)


### PR DESCRIPTION
keyerror caused brownfield test failure

> Traceback (most recent call last):
  File "/tmp/build/9b0aeb78/yoga-networking-nsx-t.git/.tox/functional/lib/python3.8/site-packages/neutron/tests/base.py", line 183, in func
    return f(self, *args, **kwargs)
  File "/tmp/build/9b0aeb78/yoga-networking-nsx-t.git/networking_nsxv3/tests/functional/test_realization_brownfield.py", line 81, in test_01_functional_generated
    y = next(self.tests_generator)
  File "/tmp/build/9b0aeb78/yoga-networking-nsx-t.git/networking_nsxv3/tests/functional/test_realization_brownfield.py", line 152, in end_to_end_test_generator
    i.port_bind(c.PORT_FRONTEND_EXTERNAL["name"], "1000")
  File "/tmp/build/9b0aeb78/yoga-networking-nsx-t.git/networking_nsxv3/tests/unit/openstack.py", line 266, in port_bind
    client.post("/api/v1/logical-ports", data={
  File "/tmp/build/9b0aeb78/yoga-networking-nsx-t.git/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py", line 114, in decorator
    sentry_extra["fingerprint"] = [RetryPolicy._create_sentry_fingerprint(kwargs["path"]),
KeyError: 'path'