### PR TITLE
Make nsxt managed objects findable in opensearch

### DIFF
--- a/networking_nsxv3/common/synchronization.py
+++ b/networking_nsxv3/common/synchronization.py
@@ -19,7 +19,7 @@ import collections
 
 LOG = logging.getLogger(__name__)
 
-MESSAGE = "{} Resource ID:{} with Priority:{} for action {}"
+MESSAGE = "{} Resource ID: {} with Priority: {} for action {}"
 INFINITY = -1
 TIMEOUT = 5
 

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/cli.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/cli.py
@@ -176,7 +176,7 @@ class NsxInventory(object):
                 for o in json.load(file):
                     id = o.get("id")
                     if id in meta:
-                        LOG.info("Object with ID:%s already processed.", id)
+                        LOG.info("Object with ID: %s already processed.", id)
                         if isinstance(meta[id], dict) and not meta[id]["rules_processed"]:
                             self._load_section_rules(full_meta, id, self.api.RULES_CREATE.format(
                                 meta[id]["id"]), os.path.join(folder_path, id))

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_mgmt.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_mgmt.py
@@ -578,8 +578,8 @@ class Provider(base.Provider):
     def _realize(self, resource_type, delete, convertor, os_o, provider_o):
         os_id = os_o.get("id")
 
-        begin_report = "[{}] Resource:{} with ID:{} is going to be %s.".format(self.provider, resource_type, os_id)
-        end_report = "[{}] Resource:{} with ID:{} has been %s.".format(self.provider, resource_type, os_id)
+        begin_report = "[{}] Resource: {} with ID: {} is going to be %s.".format(self.provider, resource_type, os_id)
+        end_report = "[{}] Resource: {} with ID: {} has been %s.".format(self.provider, resource_type, os_id)
 
         path = self.meta_provider(resource_type).endpoint
         metadata = self.metadata(resource_type, os_id)
@@ -738,7 +738,7 @@ class Provider(base.Provider):
     def sg_members_realize(self, sg, delete=False):
         if delete and self.metadata(Provider.SG_RULES, sg.get("id")):
             LOG.warning(
-                "Resource:%s with ID:%s deletion is rescheduled due to dependency.", Provider.SG_MEMBERS, sg.get("id")
+                "Resource: %s with ID: %s deletion is rescheduled due to dependency.", Provider.SG_MEMBERS, sg.get("id")
             )
             return
         return self._realize(Provider.SG_MEMBERS, delete, self.payload.sg_members_container, sg, dict())

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
@@ -433,7 +433,7 @@ class Provider(base.Provider):
     QOS = "Segment QoS"
     NETWORK = "Segment"
     PORT = "SegmentPort"
-    RESCHEDULE_WARN_MSG = "Resource:%s with ID:%s deletion is rescheduled due to dependency."
+    RESCHEDULE_WARN_MSG = "Resource: %s with ID: %s deletion is rescheduled due to dependency."
 
     def __init__(self, payload: Payload = Payload(), zone_id: str = ""):
         super(Provider, self).__init__(client=Client(), zone_id=zone_id)
@@ -576,23 +576,23 @@ class Provider(base.Provider):
             o = self.client.get(path=API.STATUS, params=params).json()
             status = o.get("consolidated_status", {}).get("consolidated_status")
             if status == "SUCCESS":
-                LOG.info("%s ID:%s in Status:%s", resource_type, os_id, status)
+                LOG.info("%s ID: %s in Status: %s", resource_type, os_id, status)
                 exporter.REALIZED.labels(resource_type, status).inc()
                 return True
             else:
-                LOG.info("%s ID:%s in Status:%s for %ss", resource_type, os_id, status, attempt * pause)
+                LOG.info("%s ID: %s in Status: %s for %ss", resource_type, os_id, status, attempt * pause)
                 eventlet.sleep(pause)
         # When multiple policies did not get realized in the defined timeframe,
         # this is a symptom for another issue.
         # This should be detected by the Prometheus after a while
         exporter.REALIZED.labels(resource_type, status).inc()
-        raise Exception("{} ID:{} did not get realized for {}s", resource_type, os_id, until * pause)
+        raise Exception("{} ID: {} did not get realized for {}s", resource_type, os_id, until * pause)
 
     # overrides
     @refresh_and_retry
     def _realize(self, resource_type: str, delete: bool, convertor: Callable, os_o: dict, provider_o: dict):
         os_id = os_o.get("id")
-        report = "Resource:{} with ID:{} is going to be %s.".format(resource_type, os_id)
+        report = "Resource: {} with ID: {} is going to be %s.".format(resource_type, os_id)
 
         meta = self.metadata(resource_type, os_id)
         if meta:
@@ -632,7 +632,7 @@ class Provider(base.Provider):
                 meta = self.metadata_update(resource_type, data)
                 self._wait_to_realize(resource_type, os_id)
                 return meta
-            LOG.info("Resource:%s with ID:%s already deleted.", resource_type, os_id)
+            LOG.info("Resource: %s with ID: %s already deleted.", resource_type, os_id)
 
     def _delete_segment_port(self, os_port: dict, port_meta: PolicyResourceMeta) -> None:
         os_id = os_port.get("id")

--- a/networking_nsxv3/tests/unit/provider.py
+++ b/networking_nsxv3/tests/unit/provider.py
@@ -203,7 +203,7 @@ class Inventory(object):
                     inventory_dump2 = json.dumps(self.inv[Inventory.PORTS], indent=2)
                     if (real_id in inventory_dump) or (real_id in inventory_dump1) or (real_id in inventory_dump2):
                         inventory[real_id] = o
-                        return self.resp(417, "SG with ID:{} cannot be deleted as either it has children or it is being referenced.".format(real_id))
+                        return self.resp(417, "SG with ID: {} cannot be deleted as either it has children or it is being referenced.".format(real_id))
             return self.resp(200) if o else self.resp(404)
 # TODO: Add support for creation of Segments and SegmentPorts
 


### PR DESCRIPTION
Searching for objects based on their UUID in Opensearch does not return the corresponding log line of type `Resource:<resource> with ID:<uuid> is going to be <action>.`. Opensearch seems to run word searches rather than substring searches, therefor searching for the UUID will not return the information needed.