### PR TITLE
Log all results which are not unique

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
@@ -259,9 +259,9 @@ class Client(metaclass=Singleton):
         results = self.get(path=path, params=params).json().get("results")
         if isinstance(results, list):
             if results:
+                if len(results) > 1:
+                    LOG.error("Ambiguous. %s", results)
                 result = results.pop()
-                if results:
-                    LOG.warning("Ambiguous. %s", results)
                 return result
         elif results:
             return results


### PR DESCRIPTION
Elements expected to be unique (e.g. ports) not fulfilling this probably require some fixture. In order to make them more visible (sentry) the loglevel is increased to error.
