### PR TITLE
Add IPv6 address of metadata service to sg rules

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/constants_nsx.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/constants_nsx.py
@@ -1,4 +1,4 @@
-
+import neutron_lib.constants as neutron_constants
 
 # IP_PROTOCOL_NUMBERS source
 # https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
@@ -233,7 +233,7 @@ DEFAULT_INFRASTRUCTURE_POLICIES = [
                 "id": "HTTP",
                 "display_name": "HTTP",
                 "source_groups": ["ANY"],
-                "destination_groups": ["169.254.169.254"],
+                "destination_groups": [neutron_constants.METADATA_V4_IP, neutron_constants.METADATA_V6_IP],
                 "services": ["/infra/services/HTTP"],
                 "service_entries": [],
                 "profiles": ["ANY"],

--- a/networking_nsxv3/tests/unit/realization/test_infrastrucutre_sg_rules.py
+++ b/networking_nsxv3/tests/unit/realization/test_infrastrucutre_sg_rules.py
@@ -1,0 +1,193 @@
+import copy
+
+import eventlet
+
+eventlet.monkey_patch()
+
+import responses
+import json
+import re
+
+from networking_nsxv3.common import config
+from neutron.tests import base
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.constants_nsx import DEFAULT_INFRASTRUCTURE_POLICIES
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import Provider
+
+
+class TestInfrastrucutreRuleChanges(base.BaseTestCase):
+    provider = None
+
+    def setUp(self):
+        super().setUp()
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+            rsps.add(
+                method=responses.GET,
+                url=re.compile(".*PolicyTransportZone.*"),
+                body='{"results": [{"display_name": "openstack-tz", "id": "openstack-tz", "tags": []}]}'
+            )
+            rsps.add(
+                method=responses.GET,
+                url=re.compile('.*\/node\/version.*'),
+                body='{"product_version": "0.0.0"}'
+            )
+            rsps.add(
+                method=responses.GET,
+                url=re.compile(".*default-layer3-logged-drop-section.*"),
+                status=200
+            )
+            rsps.add(
+                method=responses.GET,
+                url=re.compile(".*default-layer3-section.*"),
+                status=200,
+                body='{"rules": []}'
+            )
+            self.provider = Provider()
+
+    def tearDown(self):
+        super().tearDown()
+        self.provider = None
+
+    def test_change_existing_rule(self):
+        """
+        Tests whether changing an existing rule is detected
+        Additionally check if the _revision number is updated. 
+        Updating objects in NSX-T requires the _revision number to be set.
+        """
+        change_rule = {
+            "id": "ICMP_Allow",
+            "rules": [
+                {
+                    "action": "ALLOW",
+                    "display_name": "ICMP",
+                    "destination_groups": ["1.1.1.1", "8.8.8.8"]
+                }
+            ]
+        }
+
+        realized_rule = {
+            "rules": [
+                {
+                    "action": "ALLOW",
+                    "display_name": "ICMP",
+                    "path": "/infra/domains/default/security-policies/ICMP_Allow/rules/ICMP",
+                    "_revision": 1,
+                    "destination_groups": [
+                        "1.1.1.1"
+                    ],
+                }
+            ],
+            "logging_enabled": False,
+            "path": "/infra/domains/default/security-policies/ICMP_Allow",
+            "realization_id": "a579efb4-446e-47a1-a63a-ab88125a43f1",
+            "_revision": 0
+        }
+        diff = Provider._check_infrastructure_rules_for_updates(None, change_rule, realized_rule)
+        with_revision = Provider._add_revision_number(None, change_rule, realized_rule)
+        self.assertEquals(list(diff), [
+            ('add', [0, 'destination_groups'], [(1, '8.8.8.8')])])
+
+        self.assertEquals(with_revision["rules"][0]["_revision"], 1)
+        self.assertEquals(with_revision["_revision"], 0)
+
+    def test_add_new_rule_to_policy(self):
+        """
+        Tests whether adding a new rule to an existing policy is detected.
+        """
+        change_rule = {
+            "id": "ICMP_Allow",
+            "rules": [
+                {
+                    "display_name": "ICMP",
+                },
+                {
+                    "display_name": "rule2",
+                }
+            ]
+        }
+
+        realized_rule = {
+            "rules": [
+                {
+                    "display_name": "ICMP",
+                    "_revision": 1
+                }
+            ],
+            "_revision": 0
+        }
+        diff = Provider._check_infrastructure_rules_for_updates(None, change_rule, realized_rule)
+        self.assertEquals(list(diff),
+                          [('add', '', [(1, {'display_name': 'rule2'})])])
+
+    def _mock_fetch_infrastructure_policy(self, response):
+        response.add(
+            method=responses.GET,
+            url=re.compile(".*ICMP_Allow.*"),
+            body=json.dumps(DEFAULT_INFRASTRUCTURE_POLICIES[0]),
+            status=200
+        )
+        response.add(
+            method=responses.GET,
+            url=re.compile(".*Metadata_Allow.*"),
+            body=json.dumps(DEFAULT_INFRASTRUCTURE_POLICIES[1]),
+            status=200
+        )
+        response.add(
+            method=responses.GET,
+            url=re.compile(".*DHCP_Allow.*"),
+            body=json.dumps(DEFAULT_INFRASTRUCTURE_POLICIES[2]),
+            status=200
+        )
+
+    def test_infrastructure_policy_present(self):
+        """
+        Tests whether the infrastructure policies (Metadata Allow, ICMP Allow and DHCP Allow) are fetched from NSX-T.
+        No updates are made to the policies.
+        """
+        with responses.RequestsMock() as rsps:
+            self._mock_fetch_infrastructure_policy(rsps)
+
+            self.provider._setup_default_infrastructure_rules()
+
+            #Request: GET ICMP_Allow, GET Metadata_Allow, GET DHCP_Allow
+            self.assertEquals(len(rsps.calls), 3)
+            self.assertEquals(rsps.assert_all_requests_are_fired, True)
+
+    def test_infrastrucutre_policy_rule_update(self):
+        """
+        Tests whether a change in the infrastructure policy is detected.
+        Enriching the metadata policy leads to an update call for this policy.
+        """
+        metadata_policy_changed = copy.deepcopy(DEFAULT_INFRASTRUCTURE_POLICIES[1])
+        metadata_policy_changed["rules"][0]["destination_groups"] = ["8.8.8.8"]
+        metadata_policy_changed["_revision"] = 100
+        metadata_policy_changed["rules"][0]["_revision"] = 200
+
+        with responses.RequestsMock() as rsps:
+            self._mock_fetch_infrastructure_policy(rsps)
+            rsps.remove(responses.GET, re.compile(".*Metadata_Allow.*"))
+            rsps.add(
+                method=responses.GET,
+                url=re.compile(".*Metadata_Allow.*"),
+                body=json.dumps(metadata_policy_changed),
+                status=200
+            )
+            rsps.add(
+                method=responses.PUT,
+                url=re.compile(".*Metadata_Allow.*"),
+                status=200,
+                json=json.dumps(metadata_policy_changed)
+            )
+            self.provider._setup_default_infrastructure_rules()
+            req_metadata_allow = None
+            for r in rsps.calls:
+                if r.request.method == 'PUT':
+                    req_metadata_allow = r
+
+            #Request: GET ICMP_Allow, GET Metadata_Allow, GET DHCP_Allow, PUT Metadata_Allow
+            self.assertEquals(len(rsps.calls), 4)
+            self.assertEquals(rsps.assert_all_requests_are_fired, True)
+
+            #Check if the revision number is updated
+            res = json.loads(req_metadata_allow.request.body)
+            self.assertEquals(res["_revision"], 100)
+            self.assertEquals(res["rules"][0]["_revision"], 200)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ tooz
 ratelimiter                     # Apache-2.0
 prometheus_client               # Apache-2.0
 attrs                           # MIT License
+dictdiffer >=0.7.0


### PR DESCRIPTION
So far only DHCPv6 and ICMPv6 traffic is refelcted in the default infrastructure rules of NSX-T. The IPv6 address of the metadata service requires clearing as well.

In order to reflect those changes in NSX-T, it requires a check if the rule configuration has changed. So far only creation of missing policies is supported.