### PR TITLE
Log execption in catch-all exception handers

### DIFF
--- a/networking_nsxv3/common/synchronization.py
+++ b/networking_nsxv3/common/synchronization.py
@@ -179,7 +179,7 @@ class Runner(object):
                     self.active(), self.passive(), self._workers.running())
             except Exception as err:
                 # Continue on error. Otherwise the agent operation will stop
-                LOG.error(err)
+                LOG.exception("Unknown agent error: %s", err)
             EXPORTER.ACTIVE_QUEUE_SIZE.set(self.active())
             EXPORTER.PASSIVE_QUEUE_SIZE.set(self.passive())
             EXPORTER.JOB_SIZE.set(self._workers.running())

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
@@ -160,7 +160,7 @@ class NSXv3Manager(amb.CommonAgentManagerBase):
         try:
             self.realizer.all()
         except Exception as err:
-            LOG.error("Synchronization has failed. Error: %s", err)
+            LOG.exception("Synchronization has failed. Error: %s", err)
 
     def _sync_immediate(self, os_ids, realizer):
         ids = list(os_ids) if isinstance(os_ids, set) else os_ids


### PR DESCRIPTION
For better debuggability we now log the full exception in catch-all exception handlers (i.e. where we don't know what the exception is about), as LOG.error only reports a single error log line, while LOG.exception gives us the full traceback. This also makes investigation easier with sentry, as we can see the local variables of each stack frame there.