### PR TITLE
E2E Tests Improvements

### DIFF
--- a/networking_nsxv3/tests/e2e/README.md
+++ b/networking_nsxv3/tests/e2e/README.md
@@ -1,0 +1,61 @@
+# Prerequisites
+1. vSphere vCenter 8 with at least one Cluster (Building Block)
+2. NSX 4.x with configured VDS for the vCsphere Cluster from the previous req.
+3. Openstack Deployment with Agent and Driver running
+4. The following environment variables are needed for the E2E tests:
+   ```bash
+   # NSX vars
+   export NSXV3_LOGIN_HOSTNAME="nsx-l-01a.corp.local" # NSX Hostname or IP address
+   export NSXV3_LOGIN_PORT=443 # NSX HTTPS port
+   export NSXV3_LOGIN_USER="admin" # NSX Service Account USER used by the Agent
+   export NSXV3_LOGIN_PASSWORD="password" # NSX Service Account PASSWORD used by the Agent
+   export NSXV3_TRANSPORT_ZONE_NAME="bb095-vlan" # The NSX Transport Zone on which the Agent will execute the tests (Building Block)
+   
+   # OpenStack vars
+   export OS_HTTPS=0 # 0 use HTTP, 1 use HTTPS
+   export OS_HOSTNAME="os-l-01.corp.local" # OpenStack Hostname or IP address
+   export OS_USERNAME="admin" # Openstack Service Account USER
+   export OS_PASSWORD="password" # Openstack Service Account PASSWORD
+   export OS_PROJECT_NAME="admin" # Openastack Project name on which the E2E test wil run
+   export OS_PROJECT_DOMAIN_ID="default" # Openastack Project Domain ID on which the E2E test wil run
+   export OS_USER_DOMAIN_ID="default" # Openastack User Domain ID on which the E2E test wil run
+   
+   # Tox vars
+   export OS_LOG_CAPTURE=0
+   export OS_STDOUT_CAPTURE=0
+   export OS_STDERR_CAPTURE=0
+
+   # E2E Test specific vars
+   export E2E_NETWORK_NAME="test-net-1" # Pre-existing Network used for the E2E Test Scenarios
+   export E2E_SERVER_NAME="os-test-vm-1" # Pre-existing VM (server) used for the E2E Test Scenarios
+   ```
+
+# Run the E2E Tests
+   ```bash
+   tox -e e2e
+   ```
+
+# End-to-End Test Scenarios
+
+## Ports E2E Tests
+   - Create/Delete a standalone port
+   - Attach/Detach port to/from VM
+   - Create server (auto-create port)
+   - Assign/Unassign IPv4/IPv6 address
+## QOS E2E Tests
+   - Create/Delete QoS Policy
+   - Assign/Remove QoS Policy to/from port
+## Trunk E2E Tests
+   - Create/Delete trunk
+   - Add/Remove ports to/from trunk
+   - Add/Remove trunk to/from server
+   - Provision server with trunk
+## Security Groups & Policies
+   - Create/Delete/Update Security Groups (Remote IP)
+   - Create/Delete/Update Security Groups (Remote Group)
+   - Add/Remove rules to Security Groups
+   - Add/Remove ports to/from Security Group
+## Address Groups
+   - Create/Delete/Update IPv4/IPv6 address groups
+   - Create mixed IPv4/IPv6 members
+   - Address group in multiple security groups

--- a/networking_nsxv3/tests/e2e/README.md
+++ b/networking_nsxv3/tests/e2e/README.md
@@ -4,7 +4,9 @@
 3. Openstack Deployment with Agent and Driver running
 4. The Openstack "default" Security Group must exists and at least one realized and active port to be a member of it.
 5. Pre-existing Openstack network and server are required (see the ENV vars: E2E_NETWORK_NAME and E2E_SERVER_NAME).
-6. The following environment variables are needed for the E2E tests (e.g. ../developer/rc):
+6. No ports have to be provisioned on the pre-existing test network prior the tests.
+7. At least one subnet have to be available on the pre-existing test network.
+8. The following environment variables are needed for the E2E tests (e.g. ../developer/rc):
    ```bash
    # NSX vars
    export NSXV3_LOGIN_HOSTNAME="nsx-l-01a.corp.local" # NSX Hostname or IP address
@@ -52,10 +54,10 @@
    - Create/Delete QoS Policy [implemented]
    - Assign/Remove QoS Policy to/from port [partially] (depends on https://github.com/sapcc/networking-nsx-t/pull/135)
 ## Trunk E2E Tests
-   - Create/Delete trunk
-   - Add/Remove ports to/from trunk
-   - Add/Remove trunk to/from server
-   - Provision server with trunk
+   - Create/Delete trunk [implemented]
+   - Add/Remove ports to/from trunk [implemented]
+   - Add/Remove trunk to/from server [implemented]
+   - Provision server with trunk [implemented]
 ## Security Groups & Policies
    - Create/Delete/Update Security Groups (Remote IP)
    - Create/Delete/Update Security Groups (Remote Group)

--- a/networking_nsxv3/tests/e2e/README.md
+++ b/networking_nsxv3/tests/e2e/README.md
@@ -2,7 +2,9 @@
 1. vSphere vCenter 8 with at least one Cluster (Building Block)
 2. NSX 4.x with configured VDS for the vCsphere Cluster from the previous req.
 3. Openstack Deployment with Agent and Driver running
-4. The following environment variables are needed for the E2E tests:
+4. The Openstack "default" Security Group must exists and at least one realized and active port to be a member of it.
+5. Pre-existing Openstack network and server are required (see the ENV vars: E2E_NETWORK_NAME and E2E_SERVER_NAME).
+6. The following environment variables are needed for the E2E tests:
    ```bash
    # NSX vars
    export NSXV3_LOGIN_HOSTNAME="nsx-l-01a.corp.local" # NSX Hostname or IP address
@@ -28,6 +30,9 @@
    # E2E Test specific vars
    export E2E_NETWORK_NAME="test-net-1" # Pre-existing Network used for the E2E Test Scenarios
    export E2E_SERVER_NAME="os-test-vm-1" # Pre-existing VM (server) used for the E2E Test Scenarios
+   export E2E_CREATE_SERVER_NAME_PREFIX="os-e2e-test-" # Prefix for server names, UUID will be appended
+   export E2E_CREATE_SERVER_IMAGE_NAME="cirros-0.3.2-i386-disk" # Image name to use for server creation
+   export E2E_CREATE_SERVER_FLAVOR_NAME="m1.nano" # Flavor name to use for server creation
    ```
 
 # Run the E2E Tests
@@ -38,10 +43,10 @@
 # End-to-End Test Scenarios
 
 ## Ports E2E Tests
-   - Create/Delete a standalone port
-   - Attach/Detach port to/from VM
-   - Create server (auto-create port)
-   - Assign/Unassign IPv4/IPv6 address
+   - Create/Delete a standalone port [implemented]
+   - Attach/Detach port to/from VM [implemented]
+   - Create server (auto-create port) [implemented]
+   - Assign/Unassign IPv4/IPv6 address [implemented]
 ## QOS E2E Tests
    - Create/Delete QoS Policy
    - Assign/Remove QoS Policy to/from port
@@ -56,6 +61,6 @@
    - Add/Remove rules to Security Groups
    - Add/Remove ports to/from Security Group
 ## Address Groups
-   - Create/Delete/Update IPv4/IPv6 address groups
-   - Create mixed IPv4/IPv6 members
-   - Address group in multiple security groups
+   - Create/Delete/Update IPv4/IPv6 address groups [implemented]
+   - Create mixed IPv4/IPv6 members [implemented]
+   - Address group in multiple security groups [implemented]

--- a/networking_nsxv3/tests/e2e/README.md
+++ b/networking_nsxv3/tests/e2e/README.md
@@ -59,10 +59,10 @@
    - Add/Remove trunk to/from server [implemented]
    - Provision server with trunk [implemented]
 ## Security Groups & Policies
-   - Create/Delete/Update Security Groups (Remote IP)
-   - Create/Delete/Update Security Groups (Remote Group)
-   - Add/Remove rules to Security Groups
-   - Add/Remove ports to/from Security Group
+   - Create/Delete/Update Security Groups (Remote IP) [implemented]
+   - Create/Delete/Update Security Groups (Remote Group) [implemented]
+   - Add/Remove rules to Security Groups [implemented]
+   - Add/Remove ports to/from Security Group [implemented]
 ## Address Groups
    - Create/Delete/Update IPv4/IPv6 address groups [implemented]
    - Create mixed IPv4/IPv6 members [implemented]

--- a/networking_nsxv3/tests/e2e/README.md
+++ b/networking_nsxv3/tests/e2e/README.md
@@ -30,6 +30,7 @@
    export OS_STDERR_CAPTURE=0
 
    # E2E Test specific vars
+   export E2E_BB="nova" # Building block to use for E2E tests
    export E2E_NETWORK_NAME="test-net-1" # Pre-existing Network used for the E2E Test Scenarios
    export E2E_SERVER_NAME="os-test-vm-1" # Pre-existing VM (server) used for the E2E Test Scenarios
    export E2E_CREATE_SERVER_NAME_PREFIX="os-e2e-test-" # Prefix for server names, UUID will be appended

--- a/networking_nsxv3/tests/e2e/README.md
+++ b/networking_nsxv3/tests/e2e/README.md
@@ -4,7 +4,7 @@
 3. Openstack Deployment with Agent and Driver running
 4. The Openstack "default" Security Group must exists and at least one realized and active port to be a member of it.
 5. Pre-existing Openstack network and server are required (see the ENV vars: E2E_NETWORK_NAME and E2E_SERVER_NAME).
-6. The following environment variables are needed for the E2E tests:
+6. The following environment variables are needed for the E2E tests (e.g. ../developer/rc):
    ```bash
    # NSX vars
    export NSXV3_LOGIN_HOSTNAME="nsx-l-01a.corp.local" # NSX Hostname or IP address
@@ -37,6 +37,7 @@
 
 # Run the E2E Tests
    ```bash
+   source ../developer/rc
    tox -e e2e
    ```
 

--- a/networking_nsxv3/tests/e2e/README.md
+++ b/networking_nsxv3/tests/e2e/README.md
@@ -49,8 +49,8 @@
    - Create server (auto-create port) [implemented]
    - Assign/Unassign IPv4/IPv6 address [implemented]
 ## QOS E2E Tests
-   - Create/Delete QoS Policy
-   - Assign/Remove QoS Policy to/from port
+   - Create/Delete QoS Policy [implemented]
+   - Assign/Remove QoS Policy to/from port [partially] (depends on https://github.com/sapcc/networking-nsx-t/pull/135)
 ## Trunk E2E Tests
    - Create/Delete trunk
    - Add/Remove ports to/from trunk

--- a/networking_nsxv3/tests/e2e/base.py
+++ b/networking_nsxv3/tests/e2e/base.py
@@ -83,6 +83,7 @@ class E2ETestCase(base.BaseTestCase):
         cls.nsx_client = client_nsx.Client()
         cls.nsx_client.version  # This will force the client to login
         cls.OS_PROJECT_ID = cls.auth.get_project_id(cls.sess)
+        cls.availability_zone = g("E2E_BB")
 
     def setUp(self):
         super().setUp()
@@ -112,6 +113,7 @@ class E2ETestCase(base.BaseTestCase):
             min_count=1,
             max_count=1,
             security_groups=security_groups,
+            availability_zone=self.availability_zone,
             nics=[{'net-id': network_id}] if len(nic_ports) < 1 else nic_ports,
             block_device_mapping_v2=[{
                 "uuid": image.id,
@@ -240,7 +242,7 @@ class E2ETestCase(base.BaseTestCase):
     def set_test_server(self, server_name: str):
         """ Set the test server (self.test_server) to the server with the name provided.
         """
-        servers = self.nova_client.servers.list()
+        servers = self.nova_client.servers.list(search_opts={"availability_zone": self.availability_zone})
         self.test_server: Server = next((s for s in servers if s.name == server_name), None)
         self.assertIsNotNone(self.test_server, f"Server '{server_name}' not found.")
 

--- a/networking_nsxv3/tests/e2e/base.py
+++ b/networking_nsxv3/tests/e2e/base.py
@@ -1,6 +1,7 @@
 import eventlet
 eventlet.monkey_patch()
 
+from networking_nsxv3.common import config  # noqa
 from typing import List
 from keystoneauth1 import identity
 from keystoneauth1 import session
@@ -16,9 +17,6 @@ from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import client_nsx
 from oslo_config import cfg
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
 import uuid
-
-from networking_nsxv3.common import config  # noqa
-
 
 LOG = logging.getLogger(__name__)
 
@@ -244,7 +242,7 @@ class E2ETestCase(base.BaseTestCase):
         """
         servers = self.nova_client.servers.list(search_opts={"availability_zone": self.availability_zone})
         self.test_server: Server = next((s for s in servers if s.name == server_name), None)
-        self.assertIsNotNone(self.test_server, f"Server '{server_name}' not found.")
+        self.assertIsNotNone(self.test_server, f"Server '{server_name}' not found in AZ '{self.availability_zone}'.")
 
     def create_test_ports(self):
         """

--- a/networking_nsxv3/tests/e2e/base.py
+++ b/networking_nsxv3/tests/e2e/base.py
@@ -180,3 +180,18 @@ class E2ETestCase(base.BaseTestCase):
         servers = self.nova_client.servers.list()
         self.test_server: Server = next((s for s in servers if s.name == server_name), None)
         self.assertIsNotNone(self.test_server, f"Server '{server_name}' not found.")
+
+    def create_test_ports(self):
+        """ Create ports on the test network (self.test_network) and store their IDs (self.test_ports).
+            Also add cleanup for deletion.
+        """
+        for port in self.test_ports:
+            result = self.neutron_client.create_port({
+                "port": {
+                    "network_id": self.test_network['id'],
+                    "name": port['name']
+                }
+            })
+            port['id'] = result['port']['id']
+            if port['id']:
+                self.addCleanup(self.neutron_client.delete_port, port['id'])

--- a/networking_nsxv3/tests/e2e/base.py
+++ b/networking_nsxv3/tests/e2e/base.py
@@ -13,7 +13,6 @@ from oslo_log import log as logging
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import client_nsx
 from oslo_config import cfg
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
-from urllib.parse import quote
 
 from networking_nsxv3.common import config  # noqa
 
@@ -38,7 +37,8 @@ class RetryDecorator(object):
                     retry_counter -= 1
 
                 total_time = max_retries * sleep_duration
-                LOG.debug(f"No result from func '{func.__name__}' after {max_retries} retries in {total_time} seconds.")
+                LOG.debug(
+                    f"No result from func '{func.__name__}' after {max_retries} retries in {total_time} seconds.")
                 return None
 
             return wrapper
@@ -172,3 +172,10 @@ class E2ETestCase(base.BaseTestCase):
         self.test_network = next(
             (n for n in networks['networks'] if n['name'] == net_name), None)
         self.assertIsNotNone(self.test_network, f"Network '{net_name}' not found!")
+
+    def set_test_server(self, server_name: str):
+        """ Set the test server (self.test_server) to the server with the name provided.
+        """
+        servers = self.nova_client.servers.list()
+        self.test_server: Server = next((s for s in servers if s.name == server_name), None)
+        self.assertIsNotNone(self.test_server, f"Server '{server_name}' not found.")

--- a/networking_nsxv3/tests/e2e/base.py
+++ b/networking_nsxv3/tests/e2e/base.py
@@ -12,11 +12,37 @@ import os
 from oslo_log import log as logging
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import client_nsx
 from oslo_config import cfg
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
+from urllib.parse import quote
 
 from networking_nsxv3.common import config  # noqa
 
 
 LOG = logging.getLogger(__name__)
+
+
+class RetryDecorator(object):
+    @staticmethod
+    def RetryIfResultIsNone(max_retries, sleep_duration):
+        """ Retry decorator for functions that return None on failure. """
+        def decorator(func):
+            def wrapper(*args, **kwargs):
+                retry_counter = max_retries
+                while retry_counter > 0:
+                    result = func(*args, **kwargs)
+                    if result is not None:
+                        return result
+
+                    eventlet.sleep(sleep_duration)
+                    LOG.debug(f"{retry_counter}: Retrying function '{func.__name__}'\nargs: {args}\nkwargs: {kwargs}")
+                    retry_counter -= 1
+
+                total_time = max_retries * sleep_duration
+                LOG.debug(f"No result from func '{func.__name__}' after {max_retries} retries in {total_time} seconds.")
+                return None
+
+            return wrapper
+        return decorator
 
 
 class E2ETestCase(base.BaseTestCase):
@@ -35,6 +61,7 @@ class E2ETestCase(base.BaseTestCase):
         cfg.CONF.set_override("nsxv3_login_user", g("NSXV3_LOGIN_USER"), "NSXV3")
         cfg.CONF.set_override("nsxv3_login_password", g("NSXV3_LOGIN_PASSWORD"), "NSXV3")
         cfg.CONF.set_override("nsxv3_transport_zone_name", g("NSXV3_TRANSPORT_ZONE_NAME"), "NSXV3")
+        # cfg.CONF.set_override("nsxv3_default_l3_rule_check", bool(int(g("NSXV3_DEFAULT_L3_RULE_CHECK"))), "NSXV3")
         cfg.CONF.set_override("nsxv3_connection_retry_count", "3", "NSXV3")
         cfg.CONF.set_override("nsxv3_request_timeout", "320", "NSXV3")
 
@@ -52,50 +79,44 @@ class E2ETestCase(base.BaseTestCase):
         cls.neutron_client = neutron.CustomNeutronClient(session=cls.sess)
         cls.nsx_client = client_nsx.Client()
         cls.nsx_client.version  # This will force the client to login
+        cls.OS_PROJECT_ID = cls.auth.get_project_id(cls.sess)
 
-    @staticmethod
-    def retry(max_retries, sleep_duration):
-        """ Retry decorator for functions that return None on failure. """
-        def decorator(func):
-            def wrapper(*args, **kwargs):
-                retry_counter = max_retries
-                while retry_counter > 0:
-                    result = func(*args, **kwargs)
-                    if result is not None:
-                        LOG.info(f"Success after {max_retries - retry_counter} retries ({func.__name__}).")
-                        return result
+    def create_test_server(self, name, image_name, flavor_name, network_id, security_groups=["default"], no_network=False) -> Server:
+        # Get the image
+        images = self.nova_client.glance.list()
+        image = next((i for i in images if i.name == image_name), None)
+        # Assert image is found
+        self.assertIsNotNone(image)
 
-                    eventlet.sleep(sleep_duration)
-                    LOG.info(f"{retry_counter}: Retrying function '{func.__name__}'")
-                    retry_counter -= 1
+        # Get the flavor
+        flavor = self.nova_client.flavors.list()
+        flavor = next((f for f in flavor if f.name == flavor_name), None)
+        # Assert flavor is found
+        self.assertIsNotNone(flavor)
 
-                raise TimeoutError(
-                    f"Failed to fetch the desired result of func '{func.__name__}' after {max_retries} retries.")
-
-            return wrapper
-        return decorator
-
-    @classmethod
-    def create_test_server_no_ports(cls, name, image_id, flavor_id, network_id) -> Server:
-
-        srv: Server = cls.nova_client.servers.create(
+        # Create the server
+        srv: Server = self.nova_client.servers.create(
             name=name,
-            image=image_id,
-            flavor=flavor_id,
-            security_groups=["default"],
-            nics=[{'net-id': network_id}],
+            image=None,
+            flavor=flavor.id,
+            min_count=1,
+            max_count=1,
+            security_groups=security_groups,
+            nics=[{'net-id': network_id}] if not no_network else None,
             block_device_mapping_v2=[{
-                "uuid": image_id,
-                "source_type": "volume",
+                "uuid": image.id,
+                "boot_index": 0,
+                "source_type": "image",
                 "destination_type": "volume",
-                "delete_on_termination": False
+                "volume_size": 1,
+                "delete_on_termination": True
             }]
         )
 
         # Verify server is created successfully and is in 'ACTIVE' state
         timeout = 300
         while True:
-            srv: Server = cls.nova_client.servers.get(srv.id)
+            srv: Server = self.nova_client.servers.get(srv.id)
             if srv.status == "ACTIVE":
                 break
             if srv.status == "ERROR":
@@ -108,3 +129,35 @@ class E2ETestCase(base.BaseTestCase):
                 f"Waiting for server '{srv.name}' to be ACTIVE. Current status: {srv.status}, Progress: {srv.progress}%")
             eventlet.sleep(10)
         return srv
+
+    @RetryDecorator.RetryIfResultIsNone(max_retries=5, sleep_duration=5)
+    def get_nsx_port_by_os_id(self, os_port_id):
+        resp = self.nsx_client.get(API.SEARCH_QUERY, {"query": API.SEARCH_Q_SEG_PORT.format(os_port_id)})
+        if resp.ok:
+            if resp.json()['result_count'] == 0:
+                return None
+            return resp.json()['results'][0]
+        return None
+
+    @RetryDecorator.RetryIfResultIsNone(max_retries=5, sleep_duration=5)
+    def get_nsx_sg_by_os_id(self, os_sg_id):
+        resp = self.nsx_client.get(API.GROUP.format(os_sg_id))
+        if resp.ok:
+            return resp.json()
+        return None
+
+    @RetryDecorator.RetryIfResultIsNone(max_retries=5, sleep_duration=5)
+    def get_nsx_sg_effective_members(self, sg_id) -> list:
+        res = self.nsx_client.get(path=API.SEARCH_DSL, params={
+            "query": "resource_type:SegmentPort",
+            "dsl": sg_id,
+            "page_size": 100,
+            "data_source": "INTENT",
+            "exclude_internal_types": True
+        })
+        if res.ok:
+            j = res.json()
+            if j['result_count'] == 0:
+                return None
+            return j['results']
+        return None

--- a/networking_nsxv3/tests/e2e/base.py
+++ b/networking_nsxv3/tests/e2e/base.py
@@ -61,7 +61,6 @@ class E2ETestCase(base.BaseTestCase):
         cfg.CONF.set_override("nsxv3_login_user", g("NSXV3_LOGIN_USER"), "NSXV3")
         cfg.CONF.set_override("nsxv3_login_password", g("NSXV3_LOGIN_PASSWORD"), "NSXV3")
         cfg.CONF.set_override("nsxv3_transport_zone_name", g("NSXV3_TRANSPORT_ZONE_NAME"), "NSXV3")
-        # cfg.CONF.set_override("nsxv3_default_l3_rule_check", bool(int(g("NSXV3_DEFAULT_L3_RULE_CHECK"))), "NSXV3")
         cfg.CONF.set_override("nsxv3_connection_retry_count", "3", "NSXV3")
         cfg.CONF.set_override("nsxv3_request_timeout", "320", "NSXV3")
 
@@ -80,6 +79,10 @@ class E2ETestCase(base.BaseTestCase):
         cls.nsx_client = client_nsx.Client()
         cls.nsx_client.version  # This will force the client to login
         cls.OS_PROJECT_ID = cls.auth.get_project_id(cls.sess)
+
+    def setUp(self):
+        super().setUp()
+        self.test_network = None
 
     def create_test_server(self, name, image_name, flavor_name, network_id, security_groups=["default"], no_network=False) -> Server:
         # Get the image
@@ -161,3 +164,11 @@ class E2ETestCase(base.BaseTestCase):
                 return None
             return j['results']
         return None
+
+    def set_test_network(self, net_name: str):
+        """ Set the test network (self.test_network) to the network with the name provided.
+        """
+        networks = self.neutron_client.list_networks()
+        self.test_network = next(
+            (n for n in networks['networks'] if n['name'] == net_name), None)
+        self.assertIsNotNone(self.test_network, f"Network '{net_name}' not found!")

--- a/networking_nsxv3/tests/e2e/test_address_groups.py
+++ b/networking_nsxv3/tests/e2e/test_address_groups.py
@@ -1,11 +1,11 @@
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
+from networking_nsxv3.tests.e2e import base
+import uuid
+from oslo_log import log as logging
 import eventlet
 eventlet.monkey_patch()
 
 from networking_nsxv3.common import config  # noqa
-from oslo_log import log as logging
-import uuid
-from networking_nsxv3.tests.e2e import base
-from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
 
 
 LOG = logging.getLogger(__name__)
@@ -21,7 +21,8 @@ class TestAddressGroups(base.E2ETestCase):
         self.new_grp_ids = []
         self.new_sg_ids = []
         self.existing_updated_ports = []
-        self.assertGreater(len(self.nova_client.servers.list()), 0, "At least one server should exist!")
+        servers = self.nova_client.servers.list(search_opts={"availability_zone": self.availability_zone})
+        self.assertGreater(len(servers), 0, "At least one server should exist in the specified availability zone!")
         self.def_os_sg = self.get_os_default_security_group()
 
     def tearDown(self):

--- a/networking_nsxv3/tests/e2e/test_address_groups.py
+++ b/networking_nsxv3/tests/e2e/test_address_groups.py
@@ -22,7 +22,7 @@ class TestAddressGroups(base.E2ETestCase):
         self.new_sg_ids = []
         self.existing_updated_ports = []
         self.assertGreater(len(self.nova_client.servers.list()), 0, "At least one server should exist!")
-        self.def_os_sg = self._get_os_default_sg()
+        self.def_os_sg = self.get_os_default_security_group()
 
     def tearDown(self):
         super().tearDown()
@@ -360,21 +360,6 @@ class TestAddressGroups(base.E2ETestCase):
                 self.assertNotIn(sg_id, [sg['id']
                                          for sg in self.neutron_client.list_security_groups()['security_groups']])
             self.new_sg_ids = []
-
-    def _get_os_default_sg(self):
-        # Get the default security group
-        lsg = self.neutron_client.list_security_groups(project_id=self.OS_PROJECT_ID)
-        default_sg = [sg for sg in lsg['security_groups'] if sg['name'] == 'default'][0]
-
-        # Assert that the default security group exists and has active member ports
-        self.assertIsNotNone(default_sg, "Default security group must exist")
-        sg_ports = self.neutron_client.list_ports(security_groups=[default_sg['id']])
-        self.assertGreater(len(sg_ports), 0, "Default security group must have at least one port")
-        self.assertGreater(len(sg_ports['ports']), 0, "Default security group must have at least one port")
-        self.assertTrue(any([p['status'] == 'ACTIVE' and p['admin_state_up'] for p in sg_ports['ports']]),
-                        "Default security group must have at least one active port")
-
-        return default_sg
 
     def _get_assert_new_grp_id(self, unique_addr_grp_name, new_addr_grp):
         new_grp_id = None

--- a/networking_nsxv3/tests/e2e/test_address_groups.py
+++ b/networking_nsxv3/tests/e2e/test_address_groups.py
@@ -1,17 +1,23 @@
-from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
-from networking_nsxv3.tests.e2e import base
-import uuid
-from oslo_log import log as logging
 import eventlet
 eventlet.monkey_patch()
 
 from networking_nsxv3.common import config  # noqa
-
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
+from networking_nsxv3.tests.e2e import base
+from typing import List
+from novaclient.v2.servers import NetworkInterface
+import uuid
+import os
+from oslo_log import log as logging
 
 LOG = logging.getLogger(__name__)
 
 
 class TestAddressGroups(base.E2ETestCase):
+
+    def __init__(self, *args, **kwds):
+        super().__init__(*args, **kwds)
+        self.test_network1_name = os.environ.get("E2E_NETWORK_NAME", None)
 
     def setUp(self):
         super().setUp()
@@ -20,20 +26,22 @@ class TestAddressGroups(base.E2ETestCase):
         self.new_addr_grp_rules = []
         self.new_grp_ids = []
         self.new_sg_ids = []
-        self.existing_updated_ports = []
-        servers = self.nova_client.servers.list(search_opts={"availability_zone": self.availability_zone})
-        self.assertGreater(len(servers), 0, "At least one server should exist in the specified availability zone!")
+        self.new_server = None
         self.def_os_sg = self.get_os_default_security_group()
+
+        if not self.test_network1_name:
+            self.fail("E2E_NETWORK_NAME is not set. Please set it to the name of the network to use for testing.")
+        self.set_test_network(self.test_network1_name)
 
     def tearDown(self):
         super().tearDown()
         # Clean up & Assert cleanup
         LOG.info("Tearing down test case...")
-        addr_grp_ids = [ag.get("security_group_rule", {}).get("id") for ag in self.new_addr_grp_rules]
-        self._revert_updated_ports()
+        self.doCleanups()
         self._clean_neutron_sg_rules()
         self._clean_addr_groups()
         self._clean_sec_groups()
+        addr_grp_ids = [ag.get("security_group_rule", {}).get("id") for ag in self.new_addr_grp_rules]
         self._assert_nsx_cleanup(rule_ids=addr_grp_ids)
 
     def test_create_ipv4_address_groups(self):
@@ -159,9 +167,10 @@ class TestAddressGroups(base.E2ETestCase):
 
     def test_address_group_in_multiple_security_groups(self):
         LOG.info("Testing address group in multiple security groups...")
-
-        # Check that there are active ports
-        ports = self._get_assert_active_ports()
+        
+        self._create_server()
+        ports: List[NetworkInterface] = self.new_server.interface_list()
+        self.assertTrue(ports, "Server should have at least one port.")
 
         unique_addr_grp_name = str(uuid.uuid4())
         new_addr_grp = self.neutron_client.create_address_group(body={
@@ -188,12 +197,12 @@ class TestAddressGroups(base.E2ETestCase):
         })
 
         # Attach the new SGs to an active port
-        self.existing_updated_ports.append(ports[0])
-        self.neutron_client.update_port(ports[0]['id'], body={
+        self.neutron_client.update_port(ports[0].id, body={
             "port": {
                 "security_groups": [new_sg_1['security_group']['id'], new_sg_2['security_group']['id']]
             }
         })
+        self.addCleanup(self.neutron_client.delete_port, ports[0].id)
 
         # Verify that the security groups were created
         self.assertTrue(new_sg_1 and new_sg_1.get('security_group', {}).get('id'))
@@ -339,13 +348,6 @@ class TestAddressGroups(base.E2ETestCase):
                                               for ag in self.neutron_client.list_address_groups()['address_groups']])
             self.new_grp_ids = []
 
-    def _revert_updated_ports(self):
-        # Revert back the updated ports
-        if self.existing_updated_ports and len(self.existing_updated_ports) > 0:
-            for port in self.existing_updated_ports:
-                self.neutron_client.update_port(
-                    port.get("id"), {"port": {"security_groups": port.get("security_groups")}})
-
     def _clean_neutron_sg_rules(self):
         if len(self.new_addr_grp_rules) > 0:
             for new_addr_grp_rule in self.new_addr_grp_rules:
@@ -376,11 +378,18 @@ class TestAddressGroups(base.E2ETestCase):
 
         return new_grp_id
 
-    def _get_assert_active_ports(self):
-        ports = self.neutron_client.list_ports(
-            device_owner="compute:nova", admin_state_up="True", status="ACTIVE").get('ports', [])
-        self.assertTrue(ports and len(ports) > 0, "No active ports found")
-        return ports
+    def _create_server(self):
+        img_name = os.environ.get("E2E_CREATE_SERVER_IMAGE_NAME", "cirros-0.3.2-i386-disk")
+        flvr_name = os.environ.get("E2E_CREATE_SERVER_FLAVOR_NAME", "m1.nano")
+        srv_name = os.environ.get("E2E_CREATE_SERVER_NAME_PREFIX", "os-e2e-test-") + str(uuid.uuid4())
+        sg_id = self.def_os_sg['id']
+        net = self.test_network
+
+        LOG.info(
+            f"Creating a server '{srv_name}' on network '{net['name']}' with image '{img_name}', flavor '{flvr_name}' and security group ID '{sg_id}'.")
+        self.new_server = self.create_test_server(srv_name, img_name, flvr_name, net['id'], security_groups=[sg_id])
+        self.assertIsNotNone(self.new_server, "Server should be created successfully.")
+        self.addCleanup(self.nova_client.servers.delete, self.new_server.id)
 
     def _assert_and_append_new_grp_rules(self, new_addr_grp_rules):
         for rule in new_addr_grp_rules:

--- a/networking_nsxv3/tests/e2e/test_ports.py
+++ b/networking_nsxv3/tests/e2e/test_ports.py
@@ -60,7 +60,7 @@ class TestPorts(base.E2ETestCase):
         # Create a ports on the network
         LOG.info(
             f"Creating ports {[p['name'] for p in self.test_ports]} on network '{self.test_network['name']}'.")
-        self._create_ports()
+        self.create_test_ports()
 
         # Assert created ports are in the list of all ports
         LOG.info(f"Asserting created ports are in the list of all ports (in OpenStack).")
@@ -78,7 +78,7 @@ class TestPorts(base.E2ETestCase):
         # Create a ports on the network
         LOG.info(
             f"Creating ports {[p['name'] for p in self.test_ports]} on network '{self.test_network['name']}'.")
-        self._create_ports()
+        self.create_test_ports()
 
         # Attach the ports to the test server
         LOG.info(f"Attaching ports to server '{self.test_server.name}'.")
@@ -105,7 +105,7 @@ class TestPorts(base.E2ETestCase):
         # Create a ports on the network
         LOG.info(
             f"Creating ports {[p['name'] for p in self.test_ports]} on network '{self.test_network['name']}'.")
-        self._create_ports()
+        self.create_test_ports()
 
         # First attach the ports
         LOG.info(f"Attaching ports to server '{self.test_server.name}'.")
@@ -160,7 +160,7 @@ class TestPorts(base.E2ETestCase):
         # Create a ports on the network
         LOG.info(
             f"Creating ports {[p['name'] for p in self.test_ports]} on network '{self.test_network['name']}'.")
-        self._create_ports()
+        self.create_test_ports()
 
         # Attach the ports to the test server
         LOG.info(f"Attaching ports to server '{self.test_server.name}'.")
@@ -218,7 +218,7 @@ class TestPorts(base.E2ETestCase):
         # Create a ports on the network
         LOG.info(
             f"Creating ports {[p['name'] for p in self.test_ports]} on network '{self.test_network['name']}'.")
-        self._create_ports()
+        self.create_test_ports()
 
         # Attach the ports to the test server
         LOG.info(f"Attaching ports to server '{self.test_server.name}'.")
@@ -341,21 +341,6 @@ class TestPorts(base.E2ETestCase):
                               f"NSX Port for port '{port['name']}' has more than one IP assigned.")
             self.assertEquals(port_info['fixed_ips'][0]['ip_address'], nsx_port['address_bindings'][0]['ip_address'],
                               f"NSX Port for port '{port['name']}' has different IP assigned.")
-
-    def _create_ports(self):
-        """ Create ports on the test network (self.test_network) and store their IDs (self.test_ports).
-            Also add cleanup for deletion.
-        """
-        for port in self.test_ports:
-            result = self.neutron_client.create_port({
-                "port": {
-                    "network_id": self.test_network['id'],
-                    "name": port['name']
-                }
-            })
-            port['id'] = result['port']['id']
-            if port['id']:
-                self.addCleanup(self.neutron_client.delete_port, port['id'])
 
     def _attach_ports(self):
         """ Attach the ports to the test server (self.test_server). Also add cleanup for detachment.

--- a/networking_nsxv3/tests/e2e/test_ports.py
+++ b/networking_nsxv3/tests/e2e/test_ports.py
@@ -33,14 +33,10 @@ class TestPorts(base.E2ETestCase):
             self.fail("E2E_SERVER_NAME is not set. Please set it to the name of the server to use for testing.")
 
         # Get the server with the name defined in the class
-        servers = self.nova_client.servers.list()
-        self.test_server: Server = next((s for s in servers if s.name == self.test_server1_name), None)
+        self.set_test_server(self.test_server1_name)
 
         # Get the network with the name defined in the class
         self.set_test_network(self.test_network1_name)
-
-        # Assert the server and network are found
-        self.assertIsNotNone(self.test_server)
 
         # Generate a random names for ports
         self.test_ports = [

--- a/networking_nsxv3/tests/e2e/test_ports.py
+++ b/networking_nsxv3/tests/e2e/test_ports.py
@@ -1,0 +1,109 @@
+import eventlet
+eventlet.monkey_patch()
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
+from networking_nsxv3.tests.e2e import base
+import os
+import uuid
+from oslo_log import log as logging
+
+
+from networking_nsxv3.common import config  # noqa
+
+
+LOG = logging.getLogger(__name__)
+
+
+class TestPorts(base.E2ETestCase):
+
+    def __init__(self, *args, **kwds):
+        super().__init__(*args, **kwds)
+        self.test_network1_name = os.environ.get("E2E_NETWORK_NAME", None)
+        self.test_server1_name = os.environ.get("E2E_SERVER_NAME", None)
+
+    def setUp(self):
+        super().setUp()
+
+        if not self.test_network1_name:
+            self.fail("E2E_NETWORK_NAME is not set. Please set it to the name of the network to use for testing.")
+        if not self.test_server1_name:
+            self.fail("E2E_SERVER_NAME is not set. Please set it to the name of the server to use for testing.")
+
+        # Get the server with the name defined in the class
+        servers = self.nova_client.servers.list()
+        self.test_server1 = next((s for s in servers if s.name == self.test_server1_name), None)
+
+        # Get the network with the name defined in the class
+        networks = self.neutron_client.list_networks()
+        self.test_network1 = next((n for n in networks['networks'] if n['name'] == self.test_network1_name), None)
+
+        # Assert the server and network are found
+        self.assertIsNotNone(self.test_server1)
+        self.assertIsNotNone(self.test_network1)
+
+        # Generate a random names for ports
+        self.ports = [
+            {"name": "test-port-" + str(uuid.uuid4()), "id": None},
+            {"name": "test-port-" + str(uuid.uuid4()), "id": None},
+            {"name": "test-port-" + str(uuid.uuid4()), "id": None}
+        ]
+
+    def tearDown(self):
+        super().tearDown()
+        # Clean up & Assert cleanup
+        LOG.info("Tearing down test case...")
+
+        # Delete created ports
+        for port in self.ports:
+            if port['id']:
+                self.neutron_client.delete_port(port['id'])
+        ports_after_cleanup = self.neutron_client.list_ports()
+        # Assert deleted ports are not in the list og all ports
+        for port in self.ports:
+            self.assertNotIn(port['id'], [p['id'] for p in ports_after_cleanup['ports']])
+
+    def test_create_standalone_ports_and_attach(self):
+        LOG.info("Testing creation of standalone port...")
+
+        # Create a ports on the network
+        for port in self.ports:
+            result = self.neutron_client.create_port({
+                "port": {
+                    "network_id": self.test_network1['id'],
+                    "name": port['name']
+                }
+            })
+            port['id'] = result['port']['id']
+
+        # Assert created ports are in the list of all ports
+        ports_after_create = self.neutron_client.list_ports()
+        for port in self.ports:
+            self.assertIn(port['id'], [p['id'] for p in ports_after_create['ports']])
+
+        # Attach the ports to the test server
+        for port in self.ports:
+            self.nova_client.servers.interface_attach(
+                server=self.test_server1.id,
+                port_id=port['id'],
+                net_id=None,
+                fixed_ip=None
+            )
+        # Assert the ports are attached to the correct server
+        for port in self.ports:
+            self.assertEqual(self.test_server1.id, self.neutron_client.show_port(port['id'])['port']['device_id'])
+
+        # Assert the ports are created on the NSX side
+        for port in self.ports:
+            nsx_port = self.get_nsx_port_by_id(port['id'])
+            self.assertIsNotNone(nsx_port)
+
+    ##############################################################################################
+    ##############################################################################################
+
+    @base.E2ETestCase.retry(max_retries=5, sleep_duration=5)
+    def get_nsx_port_by_id(self, os_port_id):
+        resp = self.nsx_client.get(API.SEARCH_QUERY, {"query": API.SEARCH_Q_SEG_PORT.format(os_port_id)})
+        if resp.ok:
+            if resp.json()['result_count'] == 0:
+                return None
+            return resp.json()['results'][0]
+        return None

--- a/networking_nsxv3/tests/e2e/test_ports.py
+++ b/networking_nsxv3/tests/e2e/test_ports.py
@@ -1,14 +1,17 @@
 import eventlet
 eventlet.monkey_patch()
+
+from novaclient.v2.servers import Server
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
 from networking_nsxv3.tests.e2e import base
 import os
 import uuid
 from oslo_log import log as logging
-
+import ipaddress
+import random
+import copy
 
 from networking_nsxv3.common import config  # noqa
-
 
 LOG = logging.getLogger(__name__)
 
@@ -22,6 +25,7 @@ class TestPorts(base.E2ETestCase):
 
     def setUp(self):
         super().setUp()
+        # self.skipTest("Skipping test temporarily.")
 
         if not self.test_network1_name:
             self.fail("E2E_NETWORK_NAME is not set. Please set it to the name of the network to use for testing.")
@@ -30,15 +34,16 @@ class TestPorts(base.E2ETestCase):
 
         # Get the server with the name defined in the class
         servers = self.nova_client.servers.list()
-        self.test_server1 = next((s for s in servers if s.name == self.test_server1_name), None)
+        self.test_server1: Server = next((s for s in servers if s.name == self.test_server1_name), None)
 
         # Get the network with the name defined in the class
         networks = self.neutron_client.list_networks()
-        self.test_network1 = next((n for n in networks['networks'] if n['name'] == self.test_network1_name), None)
+        self.existing_test_network = next(
+            (n for n in networks['networks'] if n['name'] == self.test_network1_name), None)
 
         # Assert the server and network are found
         self.assertIsNotNone(self.test_server1)
-        self.assertIsNotNone(self.test_network1)
+        self.assertIsNotNone(self.existing_test_network)
 
         # Generate a random names for ports
         self.ports = [
@@ -47,39 +52,246 @@ class TestPorts(base.E2ETestCase):
             {"name": "test-port-" + str(uuid.uuid4()), "id": None}
         ]
 
+        self.new_server: Server = None
+
     def tearDown(self):
         super().tearDown()
         # Clean up & Assert cleanup
-        LOG.info("Tearing down test case...")
+        LOG.info("Tearing down test case.")
 
         # Delete created ports
+        self._cleanup_created_ports()
+
+        # Delete created server
+        self._cleanup_created_server()
+
+    def test_create_ports(self):
+        # Create a ports on the network
+        LOG.info(
+            f"Creating ports {[p['name'] for p in self.ports]} on network '{self.existing_test_network['name']}'.")
+        self._create_ports()
+
+        # Assert created ports are in the list of all ports
+        LOG.info(f"Asserting created ports are in the list of all ports (in OpenStack).")
+        ports_after_create = self.neutron_client.list_ports()
+        for port in self.ports:
+            self.assertIn(port['id'], [p['id'] for p in ports_after_create['ports']])
+
+        # Assert the ports are NOT created on the NSX side as they are not attached to a server
+        LOG.info(f"Asserting created ports are NOT created in NSX as they are not attached to a server.")
+        for port in self.ports:
+            nsx_port = self.get_nsx_port_by_os_id(port['id'])
+            self.assertIsNone(nsx_port)
+
+    def test_create_standalone_ports_and_attach(self):
+        # Create a ports on the network
+        LOG.info(
+            f"Creating ports {[p['name'] for p in self.ports]} on network '{self.existing_test_network['name']}'.")
+        self._create_ports()
+
+        # Attach the ports to the test server
+        LOG.info(f"Attaching ports to server '{self.test_server1.name}'.")
+        self._attach_ports()
+
+        # Assert the ports are attached to the correct server
+        LOG.info(
+            f"Asserting the ports {[p['name'] for p in self.ports]} are attached to server '{self.test_server1.name}' in Openstack.")
+        for port in self.ports:
+            self.assertEqual(self.test_server1.id, self.neutron_client.show_port(port['id'])['port']['device_id'])
+
+        # Assert the ports are created on the NSX side
+        LOG.info(f"Asserting the ports {[p['name'] for p in self.ports]} are created in NSX.")
+        for port in self.ports:
+            nsx_port = self.get_nsx_port_by_os_id(port['id'])
+            self.assertIsNotNone(nsx_port)
+
+        # Get Port Security Groups and assert the port participates in them at the NSX side
+        LOG.info(
+            f"Asserting the server '{self.test_server1.name}' ports participate in the correct security groups in NSX.")
+        self._assert_server_nsx_ports_sgs(self.test_server1.interface_list())
+
+    def test_detach_port(self):
+        # Create a ports on the network
+        LOG.info(
+            f"Creating ports {[p['name'] for p in self.ports]} on network '{self.existing_test_network['name']}'.")
+        self._create_ports()
+
+        # First attach the ports
+        LOG.info(f"Attaching ports to server '{self.test_server1.name}'.")
+        self._attach_ports()
+
+        # Assert the ports are attached to the correct server
+        LOG.info(
+            f"Asserting the ports {[p['name'] for p in self.ports]} are attached to server '{self.test_server1.name}' in Openstack.")
+        for port in self.ports:
+            self.assertEqual(self.test_server1.id, self.neutron_client.show_port(port['id'])['port']['device_id'])
+
+        # Detach the ports from the server
+        for port in self.ports:
+            # Assert that the port deattachment operations is successful
+            LOG.info(f"Detaching port '{port['name']}' from server '{self.test_server1.name}'.")
+            result = self.nova_client.servers.interface_detach(server=self.test_server1.id, port_id=port['id'])
+            self.assertIsNotNone(result, "Port deattachment operation failed.")
+
+        # We can not verify the port is removed from NSX as it will be removed after some time,
+        # defined by the "nsxv3_remove_orphan_ports_after" setting of the agent.
+
+    def test_create_server(self):
+        img_name = os.environ.get("E2E_CREATE_SERVER_IMAGE_NAME", "cirros-0.3.2-i386-disk")
+        flvr_name = os.environ.get("E2E_CREATE_SERVER_FLAVOR_NAME", "m1.nano")
+        srv_name = os.environ.get("E2E_CREATE_SERVER_NAME_PREFIX", "os-e2e-test-") + str(uuid.uuid4())
+        sg_name = "default"
+        net = self.existing_test_network
+
+        LOG.info(
+            f"Creating a server '{srv_name}' on network '{net['name']}' with image '{img_name}', flavor '{flvr_name}' and security group '{sg_name}'.")
+        self.new_server = self.create_test_server(
+            srv_name, img_name, flvr_name, net['id'], security_groups=[sg_name])
+
+        # Assert server has the "default" security group
+        LOG.info(f"Asserting server '{self.new_server.name}' has the 'default' security group in OpenStack.")
+        self._assert_os_server_default_sg(self.new_server)
+
+        # Assert that on NSX side the server has the default security group
+        LOG.info(f"Asserting server '{self.new_server.name}' has the 'default' security group in NSX.")
+        self._assert_server_nsx_sg(self.new_server)
+
+        # Assert the server's ports are created on the NSX side
+        LOG.info(f"Asserting server '{self.new_server.name}' has its ports created in NSX.")
+        self._assert_server_nsx_ports(self.new_server)
+
+        # Assert the server's ports are members of the correct security groups in NSX
+        LOG.info(f"Asserting server '{self.new_server.name}' ports are members of the correct security groups in NSX.")
+        self._assert_server_nsx_ports_sgs(self.new_server.interface_list())
+
+    def test_assign_unassign_ipv4_to_port(self):
+        # Create a ports on the network
+        LOG.info(
+            f"Creating ports {[p['name'] for p in self.ports]} on network '{self.existing_test_network['name']}'.")
+        self._create_ports()
+
+        # Attach the ports to the test server
+        LOG.info(f"Attaching ports to server '{self.test_server1.name}'.")
+        self._attach_ports()
+
+        # Assert the ports are attached to the correct server
+        LOG.info(
+            f"Asserting the ports {[p['name'] for p in self.ports]} are attached to server '{self.test_server1.name}' in Openstack.")
+        for port in self.ports:
+            self.assertEqual(self.test_server1.id, self.neutron_client.show_port(port['id'])['port']['device_id'])
+
+        # Assert the ports are created on the NSX side
+        LOG.info(f"Asserting the ports {[p['name'] for p in self.ports]} are created in NSX.")
+        for port in self.ports:
+            nsx_port = self.get_nsx_port_by_os_id(port['id'])
+            self.assertIsNotNone(nsx_port)
+
+        # Get Port Security Groups and assert the port participates in them at the NSX side
+        LOG.info(
+            f"Asserting the server '{self.test_server1.name}' ports participate in the correct security groups in NSX.")
+        self._assert_server_nsx_ports_sgs(self.test_server1.interface_list())
+
+        # Get the CIDR from the specified netowkr subnets on the OpenStack side
+        cidr = self.neutron_client.show_subnet(self.existing_test_network['subnets'][0])['subnet']['cidr']
+        all_ips = [str(ip) for ip in ipaddress.IPv4Network(cidr)]
+        ips = copy.deepcopy(all_ips[2:-2])
+        for port in self.ports:
+            # Get random IP from the CIDR
+            ip = random.choice(ips)
+            ips.pop(ips.index(ip))
+            LOG.info(f"Assigning IP '{ip}' to port '{port['name']}'.")
+            p = self.neutron_client.show_port(port['id'])['port']
+            # Append the IP to the port fixed IPs
+            p['fixed_ips'].append({"ip_address": ip})
+            self.neutron_client.update_port(port['id'], {"port": {"fixed_ips": p['fixed_ips']}})
+
+        # Assert the IP is assigned to the port
+        for port in self.ports:
+            port_info = self.neutron_client.show_port(port['id'])['port']
+            for ip in port_info['fixed_ips']:
+                self.assertIn(
+                    ip['ip_address'], all_ips, f"Assigned IP '{ip['ip_address']}' is not in the CIDR '{cidr}' for port '{port['name']}'.")
+
+        # Assert the IP is assigned to the port in NSX
+        for port in self.ports:
+            eventlet.sleep(10)  # Wait for the NSX to update the port
+            nsx_port = self.get_nsx_port_by_os_id(port['id'])
+            self.assertIsNotNone(nsx_port)
+            port_info = self.neutron_client.show_port(port['id'])['port']
+            for ip in port_info['fixed_ips']:
+                self.assertIn(ip['ip_address'], [p['ip_address'] for p in nsx_port['address_bindings']],
+                              f"Assigned IP '{ip['ip_address']}' is not in the NSX Port for port '{port['name']}'.")
+
+    def test_assign_unassign_ipv6_to_port(self):
+        # TODO: Implement this test
+        pass
+
+    ##############################################################################################
+    ##############################################################################################
+
+    def _cleanup_created_ports(self):
         for port in self.ports:
             if port['id']:
                 self.neutron_client.delete_port(port['id'])
+
         ports_after_cleanup = self.neutron_client.list_ports()
-        # Assert deleted ports are not in the list og all ports
+
+        # Assert deleted ports are not in the list of all ports
         for port in self.ports:
-            self.assertNotIn(port['id'], [p['id'] for p in ports_after_cleanup['ports']])
+            self.assertNotIn(port['id'], [p['id'] for p in ports_after_cleanup.get('ports', [])])
 
-    def test_create_standalone_ports_and_attach(self):
-        LOG.info("Testing creation of standalone port...")
+    def _cleanup_created_server(self):
+        if self.new_server:
+            self.nova_client.servers.delete(self.new_server.id)
+            # Await server deletion
+            while True:
+                try:
+                    self.nova_client.servers.get(self.new_server.id)
+                    eventlet.sleep(10)
+                except Exception as e:
+                    break
+            # Assert server is deleted
+            self.assertRaises(Exception, self.nova_client.servers.get, self.new_server.id)
 
-        # Create a ports on the network
+    def _assert_server_nsx_ports(self, server: Server):
+        for port in server.interface_list():
+            nsx_port = self.get_nsx_port_by_os_id(port.id)
+            self.assertIsNotNone(nsx_port, f"OS '{port.id}' Port not found in NSX.")
+            self.assertIn(port.mac_addr, [p['mac_address'] for p in nsx_port['address_bindings']],
+                          "OS Port MAC address not found in the realized NSX Port.")
+            self.assertIn(port.fixed_ips[0]['ip_address'], [
+                          p['ip_address'] for p in nsx_port['address_bindings']], "OS Port IP address not found in the realized NSX Port.")
+
+    def _assert_server_nsx_sg(self, server: Server):
+        sg_id = next((sg.id for sg in server.list_security_group() if sg.name == "default"), None)
+        nsx_sg = self.get_nsx_sg_by_os_id(sg_id)
+        self.assertIsNotNone(nsx_sg, "Security Group 'default' not found in NSX.")
+
+    def _assert_os_server_default_sg(self, server: Server):
+        self.assertIn("default", [sg.name for sg in server.list_security_group()])
+
+    def _assert_server_nsx_ports_sgs(self, ports: list):
+        for port in ports:
+            port_sgs = self.neutron_client.show_port(port.id)['port']['security_groups']
+            # For each SG get the Group from NSX and its members
+            for sg_id in port_sgs:
+                nsx_ports_for_sg = self.get_nsx_sg_effective_members(sg_id)
+                self.assertIsNotNone(nsx_ports_for_sg, f"Security Group {sg_id} not found in NSX.")
+                # Assert the port is a member of the SG
+                nsx_port = next((p for p in nsx_ports_for_sg if p['display_name'] == port.id), None)
+                self.assertIsNotNone(nsx_port, f"Port {port.id} not found in Security Group {sg_id} in NSX.")
+
+    def _create_ports(self):
         for port in self.ports:
             result = self.neutron_client.create_port({
                 "port": {
-                    "network_id": self.test_network1['id'],
+                    "network_id": self.existing_test_network['id'],
                     "name": port['name']
                 }
             })
             port['id'] = result['port']['id']
 
-        # Assert created ports are in the list of all ports
-        ports_after_create = self.neutron_client.list_ports()
-        for port in self.ports:
-            self.assertIn(port['id'], [p['id'] for p in ports_after_create['ports']])
-
-        # Attach the ports to the test server
+    def _attach_ports(self):
         for port in self.ports:
             self.nova_client.servers.interface_attach(
                 server=self.test_server1.id,
@@ -87,23 +299,3 @@ class TestPorts(base.E2ETestCase):
                 net_id=None,
                 fixed_ip=None
             )
-        # Assert the ports are attached to the correct server
-        for port in self.ports:
-            self.assertEqual(self.test_server1.id, self.neutron_client.show_port(port['id'])['port']['device_id'])
-
-        # Assert the ports are created on the NSX side
-        for port in self.ports:
-            nsx_port = self.get_nsx_port_by_id(port['id'])
-            self.assertIsNotNone(nsx_port)
-
-    ##############################################################################################
-    ##############################################################################################
-
-    @base.E2ETestCase.retry(max_retries=5, sleep_duration=5)
-    def get_nsx_port_by_id(self, os_port_id):
-        resp = self.nsx_client.get(API.SEARCH_QUERY, {"query": API.SEARCH_Q_SEG_PORT.format(os_port_id)})
-        if resp.ok:
-            if resp.json()['result_count'] == 0:
-                return None
-            return resp.json()['results'][0]
-        return None

--- a/networking_nsxv3/tests/e2e/test_ports.py
+++ b/networking_nsxv3/tests/e2e/test_ports.py
@@ -1,6 +1,7 @@
 import eventlet
 eventlet.monkey_patch()
 
+from networking_nsxv3.common import config  # noqa
 from novaclient.v2.servers import Server
 from networking_nsxv3.tests.e2e import base
 import os
@@ -9,8 +10,6 @@ from oslo_log import log as logging
 import ipaddress
 import random
 import copy
-
-from networking_nsxv3.common import config  # noqa
 
 LOG = logging.getLogger(__name__)
 

--- a/networking_nsxv3/tests/e2e/test_qos.py
+++ b/networking_nsxv3/tests/e2e/test_qos.py
@@ -1,13 +1,12 @@
 import eventlet
 eventlet.monkey_patch()
 
+from networking_nsxv3.common import config  # noqa
 from oslo_log import log as logging
 import uuid
 import os
 from networking_nsxv3.tests.e2e import base
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
-
-from networking_nsxv3.common import config  # noqa
 
 LOG = logging.getLogger(__name__)
 

--- a/networking_nsxv3/tests/e2e/test_qos.py
+++ b/networking_nsxv3/tests/e2e/test_qos.py
@@ -35,6 +35,8 @@ class TestQoS(base.E2ETestCase):
         super().tearDown()
 
     def test_create_qos(self):
+        LOG.info(f"Testing QoS Policy creation and deletion")
+
         # Create QoS Policy
         LOG.info(f"Creating QoS Policy '{self.qos_policy_name}'")
         qos_policy = self.neutron_client.create_qos_policy({'policy': {'name': self.qos_policy_name}})

--- a/networking_nsxv3/tests/e2e/test_qos.py
+++ b/networking_nsxv3/tests/e2e/test_qos.py
@@ -1,0 +1,115 @@
+import eventlet
+eventlet.monkey_patch()
+
+from oslo_log import log as logging
+import uuid
+import os
+from networking_nsxv3.tests.e2e import base
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
+
+from networking_nsxv3.common import config  # noqa
+
+LOG = logging.getLogger(__name__)
+
+
+class TestQoS(base.E2ETestCase):
+
+    def __init__(self, *args, **kwds):
+        super().__init__(*args, **kwds)
+        self.test_server1_name = os.environ.get("E2E_SERVER_NAME", None)
+
+    def setUp(self):
+        super().setUp()
+        # self.skipTest("Skipping test temporarily.")
+
+        if not self.test_server1_name:
+            self.fail("E2E_SERVER_NAME is not set. Please set it to the name of the server to use for testing.")
+
+        # Get the server with the name defined in the class
+        self.set_test_server(self.test_server1_name)
+
+        self.qos_policy_name = f"e2e_test_qos_policy_{uuid.uuid4()}"
+        self.bandwidth_limit_rule = {'max_kbps': 2048, 'max_burst_kbps': 2048, 'direction': 'egress'}
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test_create_qos(self):
+        # Create QoS Policy
+        LOG.info(f"Creating QoS Policy '{self.qos_policy_name}'")
+        qos_policy = self.neutron_client.create_qos_policy({'policy': {'name': self.qos_policy_name}})
+        self.assertIsNotNone(qos_policy)
+
+        # Add QoS Rule to QoS Policy
+        LOG.info(f"Adding Bandwidth Limit Rule to QoS Policy '{self.qos_policy_name}'")
+        qos_rule = self.neutron_client.create_bandwidth_limit_rule(
+            qos_policy['policy']['id'], {'bandwidth_limit_rule': self.bandwidth_limit_rule})
+        self.assertIsNotNone(qos_rule)
+
+        # Get Server Ports
+        server_ports = self.neutron_client.list_ports(device_id=self.test_server.id)['ports']
+        self.assertTrue(len(server_ports) > 0, f"Server {self.test_server.id} has no ports.")
+
+        # Attach QoS Policy to Server Port
+        server_port = server_ports[0]
+        LOG.info(f"Attaching QoS Policy '{self.qos_policy_name}' to Server Port '{server_port['id']}'")
+        self.neutron_client.update_port(server_port['id'], {'port': {'qos_policy_id': qos_policy['policy']['id']}})
+
+        # Assert QoS Profile is created in NSX
+        nsx_qos_prfl = self.get_nsx_qos_by_os_id(qos_policy['policy']['id'])
+        self.assertIsNotNone(nsx_qos_prfl, f"QoS Profile '{self.qos_policy_name}' was not created in NSX")
+        self.assertDictContainsSubset({
+            'id': qos_policy['policy']['id'],
+            'display_name': qos_policy['policy']['id'],
+        }, nsx_qos_prfl)
+        self.assertDictContainsSubset({
+            'resource_type': 'EgressRateLimiter',
+            'enabled': True,
+            'average_bandwidth': int(self.bandwidth_limit_rule['max_kbps']/1024),
+            # 'burst_size': int(self.bandwidth_limit_rule['max_burst_kbps']/1024), # TODO: Pending https://github.com/sapcc/networking-nsx-t/pull/135
+        }, nsx_qos_prfl['shaper_configurations'][0])
+
+        # Assert QoS Policy is attached to Server Port in NSX
+        nsx_port = self.get_nsx_port_by_os_id(server_port['id'])
+        self.assertIsNotNone(nsx_port, f"Server Port '{server_port['id']}' was not found in NSX")
+        # TODO: Assert QoS Policy is attached to Server Port in NSX after PR https://github.com/sapcc/networking-nsx-t/pull/135 is merged
+
+        # Detach QoS Policy from Server Port
+        LOG.info(f"Detaching QoS Policy '{self.qos_policy_name}' from Server Port '{server_port['id']}'")
+        self.neutron_client.update_port(server_port['id'], {'port': {'qos_policy_id': None}})
+        eventlet.sleep(10)
+
+        # Delete Qos Policy Rule
+        LOG.info(f"Deleting Bandwidth Limit Rule from QoS Policy '{self.qos_policy_name}'")
+        self.neutron_client.delete_bandwidth_limit_rule(
+            qos_rule['bandwidth_limit_rule']['id'], qos_policy['policy']['id'])
+        eventlet.sleep(10)
+
+        # Delete QoS Policy
+        LOG.info(f"Deleting QoS Policy '{self.qos_policy_name}'")
+        try:
+            self.neutron_client.delete_qos_policy(qos_policy['policy']['id'])
+        except Exception as e:
+            pass  # TODO: Pending https://github.com/sapcc/networking-nsx-t/pull/135
+        eventlet.sleep(10)
+
+        # Assert QoS Profile is deleted from NSX
+        self.assertTrue(self.get_nsx_qos_by_os_id_after_clean(
+            qos_policy['policy']['id']), f"QoS Profile '{self.qos_policy_name}' was not deleted from NSX")
+
+    ##############################################################################################
+    ##############################################################################################
+
+    @base.RetryDecorator.RetryIfResultIsNone(max_retries=5, sleep_duration=5)
+    def get_nsx_qos_by_os_id(self, os_qos_id):
+        resp = self.nsx_client.get(API.QOS_PROFILE.format(os_qos_id))
+        if resp.ok:
+            return resp.json()
+        return None
+
+    @base.RetryDecorator.RetryIfResultIsNone(max_retries=5, sleep_duration=5)
+    def get_nsx_qos_by_os_id_after_clean(self, os_qos_id):
+        resp = self.nsx_client.get(API.QOS_PROFILE.format(os_qos_id))
+        if resp.ok:
+            return None
+        return True

--- a/networking_nsxv3/tests/e2e/test_security_groups.py
+++ b/networking_nsxv3/tests/e2e/test_security_groups.py
@@ -1,0 +1,341 @@
+import eventlet
+eventlet.monkey_patch()
+
+from neutronclient.common.exceptions import NotFound
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
+import random
+import ipaddress
+from oslo_log import log as logging
+import uuid
+import os
+from networking_nsxv3.tests.e2e import base
+from novaclient.v2.servers import Server
+
+from networking_nsxv3.common import config  # noqa
+
+LOG = logging.getLogger(__name__)
+
+
+class TestSecurityGroups(base.E2ETestCase):
+
+    def __init__(self, *args, **kwds):
+        super().__init__(*args, **kwds)
+        self.test_network1_name = os.environ.get("E2E_NETWORK_NAME", None)
+        self.test_server1_name = os.environ.get("E2E_SERVER_NAME", None)
+
+    def setUp(self):
+        super().setUp()
+        # self.skipTest("Skipping test temporarily.")
+
+        if not self.test_network1_name:
+            self.fail("E2E_NETWORK_NAME is not set. Please set it to the name of the network to use for testing.")
+        if not self.test_server1_name:
+            self.fail("E2E_SERVER_NAME is not set. Please set it to the name of the server to use for testing.")
+
+        # Get the server with the name defined in the class
+        self.set_test_server(self.test_server1_name)
+
+        # Get the network with the name defined in the class
+        self.set_test_network(self.test_network1_name)
+
+        ports = self.neutron_client.list_ports(network_id=self.test_network['id'])['ports']
+        if ports and len(ports) > 0:
+            self.fail(f"Network '{self.test_network['name']}' has ports. Please use a network without ports.")
+
+        self.test_network['subnets'] = [s['id'] for s in self.neutron_client.list_subnets(
+            network_id=self.test_network['id'])['subnets']]
+        if not self.test_network['subnets'] or len(self.test_network['subnets']) < 1:
+            self.fail(f"Network '{self.test_network['name']}' has no subnets. Please use a network with subnets.")
+
+        # Generate a random names for ports
+        self.test_ports = [
+            {"name": "e2e-sg-port-" + str(uuid.uuid4()), "id": None},
+            {"name": "e2e-sg-port-" + str(uuid.uuid4()), "id": None},
+            {"name": "e2e-sg-port-" + str(uuid.uuid4()), "id": None}
+        ]
+
+        self.test_sgs = []
+        self.def_os_sg = self.get_os_default_security_group()
+
+        self.new_server: Server = None
+
+    def tearDown(self):
+        super().tearDown()
+
+        # Clean up & Assert cleanup
+        LOG.info("Tearing down test case.")
+        self.doCleanups()
+        self.assert_security_groups_deleted()
+
+    def test_create_security_group(self):
+        LOG.info("Testing Create Security Groups")
+
+        # Create some Security Groups and store their IDs
+        self.create_security_groups()
+
+        # Add all types of rules to the security groups
+        LOG.info("Adding rules to the Security Groups")
+        self.add_rules_to_security_groups()
+
+        # Assert the Security Groups are NOT created in NSX, as there are no ports associated with them
+        LOG.info("Verifying Security Groups are NOT created in NSX, as there are no ports associated with them.")
+        for sg in self.test_sgs:
+            nsx_sg = self.get_nsx_sg_by_os_id(sg['id'])
+            self.assertIsNone(nsx_sg, f"Security Group {sg['id']} was created in NSX, but it should not have been.")
+
+    def test_add_port_to_security_group_tag_membership_remote_ip_prefix(self):
+        LOG.info("Testing Add Port to Security Group with Tag Membership and Remote IP Prefix Rules")
+        self._test_add_port_to_security_group(rules=['remote_ip_prefix'], sg_count=4)
+
+    def test_add_port_to_security_group_static_membership_remote_ip_prefix(self):
+        LOG.info("Testing Add Port to Security Group with Static Membership and Remote IP Prefix Rules")
+        self._test_add_port_to_security_group(rules=['remote_ip_prefix'], sg_count=60)
+
+    def _test_add_port_to_security_group(self, rules, sg_count):
+        # Create some Security Groups and store their IDs
+        LOG.info(f"Creating {sg_count} Security Groups")
+        self.create_security_groups(sg_count=sg_count)
+
+        # Add Remote IP Prefix rules to the security groups
+        LOG.info("Adding Remote IP Prefix rules to the Security Groups")
+        self.add_rules_to_security_groups(rules=rules)
+
+        # Create a port and associate it with the Security Groups
+        LOG.info(f"Creating {len(self.test_ports)} Ports")
+        self.create_test_ports()
+
+        LOG.info("Adding Ports to the Security Groups")
+        for i, port in enumerate(self.test_ports):
+            sgs_slice = self.get_sgs_slice(stateful=i % 2 == 0)
+            self.neutron_client.update_port(port['id'], {'port': {'security_groups': [sg['id'] for sg in sgs_slice]}})
+
+        # Sleep for a few seconds to allow the ports to be added to the Security Groups
+        eventlet.sleep(10)
+
+        # Assert the ports are added to the Security Groups in OpenStack
+        LOG.info("Verifying Ports are added to the Security Groups in OpenStack")
+        for i, port in enumerate(self.test_ports):
+            sgs_slice = self.get_sgs_slice(stateful=i % 2 == 0)
+            os_port = self.neutron_client.show_port(port['id'])['port']
+            self.assertIsNotNone(os_port, f"Port {port['id']} not found in OpenStack.")
+            self.assertEqual(len(os_port['security_groups']), len(sgs_slice),
+                             f"Port {port['id']} is not in the correct number of Security Groups.")
+            for sg in sgs_slice:
+                self.assertIn(sg['id'], os_port['security_groups'],
+                              f"Port {port['id']} is not in Security Group {sg['id']}.")
+
+        # Attach the ports to the server
+        LOG.info(f"Attaching Ports to the Test Server '{self.test_server1_name}'")
+        self.attach_test_ports_to_test_server()
+
+        # Sleep for a few seconds to allow the ports to be attached to the server
+        eventlet.sleep(10)
+
+        # Assert Security Groups are created in NSX and the ports are associated with them
+        LOG.info("Verifying Security Groups are created in NSX and the ports are associated with them")
+        attached_ports = self.test_server.interface_list()
+        for p in self.test_ports:
+            self.assertIn(p['id'], [p.id for p in attached_ports], f"Port {p['id']} not attached to the server.")
+        self.assert_os_ports_nsx_sg_membership(attached_ports)
+
+    ##############################################################################################
+    ##############################################################################################
+
+    def get_sgs_slice(self, stateful=True):
+        if stateful:
+            return [sg for sg in self.test_sgs if sg['stateful']]
+        return [sg for sg in self.test_sgs if not sg['stateful']]
+
+    def add_rules_to_security_groups(self, rules=['all']):
+        """
+        Adds rules to the security groups.
+
+        This method clears all the existing rules in the security groups and then adds rules to each security group.
+        The rules include ingress and egress rules for both IPv4 and IPv6, ICMP rules, remote group rules,
+        and remote IP prefix rules.
+
+        Parameters:
+        rule_types (lsit[str]): The types of rules to add. Default is 'all'.
+                                Other options are 'icmp', 'remote_group', 'remote_ip_prefix', 'port_range'
+
+        Returns:
+            None
+        """
+
+        # First clear all the rules in the security group
+        for sg in self.test_sgs:
+            sg_os = self.neutron_client.show_security_group(sg['id'])['security_group']
+            self.assertIsNotNone(sg_os, f"Security Group {sg['id']} not found in OpenStack.")
+            for rule in sg_os['security_group_rules']:
+                self.neutron_client.delete_security_group_rule(rule['id'])
+
+        # Assert the rules are deleted in OpenStack by checking the number of rules in each Security Group
+        for sg in self.test_sgs:
+            sg_os = self.neutron_client.show_security_group(sg['id'])['security_group']
+            self.assertIsNotNone(sg_os, f"Security Group {sg['id']} not found in OpenStack.")
+            self.assertEqual(len(sg_os['security_group_rules']), 0)
+
+        for sg in self.test_sgs:
+            LOG.info(f"Adding rules to Security Group {sg['id']} ({sg['name']})")
+            # Define the rule parameters
+            rule_params = {
+                "security_group_rule": {}
+            }
+            # Define the list of rule types to create
+            remote_ip_prefix_rules, remote_group_rules, icmp_rules, port_range_rules = self.sg_rules_fixture()
+            rules = []
+
+            # 1. Remote IP Prefix rule types
+            if 'all' in rules or 'remote_ip_prefix' in rules:
+                rules.extend(remote_ip_prefix_rules)
+
+            # 2. Remote Group rule types
+            if 'all' in rules or 'remote_group' in rules:
+                rules.extend(remote_group_rules)
+
+            # 3. ICMP rule types
+            if 'all' in rules or 'icmp' in rules:
+                rules.extend(icmp_rules)
+
+            # 4. Port range rule types
+            if 'all' in rules or 'port_range' in rules:
+                rules.extend(port_range_rules)
+
+            # Create the rules
+            for rule_type in rules:
+                LOG.info(f"Creating rule: {rule_type['description']}")
+                rule_params["security_group_rule"] = {
+                    "security_group_id": sg['id']
+                }
+                rule_params["security_group_rule"].update(rule_type)
+                self.neutron_client.create_security_group_rule(rule_params)
+
+        # Assert the rules are created in OpenStack by checking the number of rules in each Security Group
+        for sg in self.test_sgs:
+            sg_os = self.neutron_client.show_security_group(sg['id'])['security_group']
+            self.assertIsNotNone(sg_os, f"Security Group {sg['id']} not found in OpenStack.")
+            self.assertGreaterEqual(len(sg_os['security_group_rules']), len(rules))
+
+    def create_security_groups(self, sg_count=10):
+        """
+        Create multiple security groups and store their IDs in the self.test_sgs list.
+        The method creates a number of security groups with half of them being stateful and the other half stateless.
+
+        Args:
+            sg_count (int): The number of security groups to create. Default is 10.
+
+        Returns:
+            None
+        """
+        self.test_sgs = self.sgs_fixture(n=sg_count)
+        count_stateful = int(sg_count / 2)
+
+        LOG.info(f"Creating {sg_count} Security Groups, with {count_stateful} of them being stateful.")
+        for i, sg in enumerate(self.test_sgs):
+            stateful = i < count_stateful
+            LOG.info(f"Creating {'STATEFUL' if stateful else 'STATELESS'} Security Group: {sg['name']}")
+            result = self.neutron_client.create_security_group(
+                {"security_group": {"name": sg['name'], "stateful": stateful}})
+            sg['id'] = result['security_group']['id']
+            sg['stateful'] = stateful
+            self.assertIsNotNone(sg['id'])
+            self.addCleanup(self.neutron_client.delete_security_group, sg['id'])
+
+        # Verify the Security Groups are created in OpenStack
+        LOG.info("Verifying Security Groups are created in OpenStack")
+        for sg in self.test_sgs:
+            sg_os = self.neutron_client.show_security_group(sg['id'])['security_group']
+            self.assertIsNotNone(sg_os, f"Security Group {sg['id']} not found in OpenStack.")
+            self.assertDictContainsSubset({
+                'id': sg['id'],
+                'name': sg['name'],
+            }, sg_os)
+
+    def assert_security_groups_deleted(self):
+        """
+        Assert that the security groups are deleted.
+        """
+        for sg in self.test_sgs:
+            self.assertRaises(NotFound, self.neutron_client.show_security_group, sg['id'])
+
+    @base.RetryDecorator.RetryIfResultIsNone(max_retries=1, sleep_duration=2)
+    def get_nsx_sg_by_os_id(self, os_sg_id):
+        resp = self.nsx_client.get(API.GROUP.format(os_sg_id))
+        if resp.ok:
+            return resp.json()
+        return None
+
+    def sgs_fixture(self, n=10):
+        """
+        Generate a list of security group fixtures.
+
+        Args:
+            n (int): The number of security group fixtures to generate. Default is 10.
+
+        Returns:
+            list: A list of dictionaries representing the security group fixtures. Each dictionary
+                  contains the 'name' and 'id' of the security group.
+        """
+        return [
+            {"name": f"e2e-sg{i+1}-" + str(uuid.uuid4()), "id": None, "stateful": None}
+            for i in range(n)
+        ]
+
+    def sg_rules_fixture(self):
+        """
+        Returns a tuple containing different types of security group rules.
+
+        The tuple contains the following rule types:
+        1. Remote IP Prefix rule types
+        2. Remote Group rule types
+        3. ICMP rule types
+        4. Port range rule types
+
+        Each rule type is represented as a dictionary with specific attributes.
+
+        Returns:
+            tuple: A tuple containing different types of security group rules.
+        """
+        # 1. Remote IP Prefix rule types
+        remote_prefix_rules = [
+            {"description": "E2E Test Egress IPv4/TCP rule with random remote IP prefix", "direction": "egress",
+             "ethertype": "IPv4", "protocol": "tcp", "remote_ip_prefix": str(ipaddress.IPv4Address(random.randint(0, 2**32-1)))},
+            {"description": "E2E Test Ingress IPv6/TCP rule with random remote IP prefix", "direction": "ingress",
+             "ethertype": "IPv6", "protocol": "tcp", "remote_ip_prefix": str(ipaddress.IPv6Address(random.randint(0, 2**128-1)))}
+        ]
+
+        # 2. Remote Group rule types
+        remote_group_rules = [
+            {"description": "E2E Test Egress IPv4/UDP rule with remote group", "direction": "egress",
+                "ethertype": "IPv4", "protocol": "udp", "remote_group_id": self.def_os_sg['id']},
+            {"description": "E2E Test Ingress IPv6/UDP rule with remote group", "direction": "ingress",
+                "ethertype": "IPv6", "protocol": "tcp", "remote_group_id": self.def_os_sg['id']}
+        ]
+
+        # 3. ICMP rule types
+        icmp_rules = [
+            {"description": "E2E Test Ingress IPv4/ICMP rule",
+                "direction": "ingress", "ethertype": "IPv4", "protocol": "icmp"},
+            {"description": "E2E Test Egress IPv4/ICMP rule", "direction": "egress", "ethertype": "IPv4", "protocol": "icmp"},
+            {"description": "E2E Test Ingress IPv6/ICMP rule",
+                "direction": "ingress", "ethertype": "IPv6", "protocol": "icmp"},
+            {"description": "E2E Test Egress IPv6/ICMP rule", "direction": "egress", "ethertype": "IPv6", "protocol": "icmp"}
+        ]
+
+        # 4. Port range rule types
+        port_range_rules = [
+            {"description": "E2E Test Egress IPv4/ANY rule", "direction": "egress",
+                "ethertype": "IPv4", "protocol": None, "port_range_min": None, "port_range_max": None},
+            {"description": "E2E Test Ingress IPv4/UDP port range (1024-2048) rule", "direction": "ingress",
+             "ethertype": "IPv4", "protocol": "udp", "port_range_min": 1024, "port_range_max": 2048},
+            {"description": "E2E Test Ingress IPv4/TCP HTTP rule", "direction": "ingress",
+                "ethertype": "IPv4", "protocol": "tcp", "port_range_min": 80, "port_range_max": 80},
+            {"description": "E2E Test Egress IPv4/TCP HTTPS rule", "direction": "egress",
+                "ethertype": "IPv4", "protocol": "tcp", "port_range_min": 443, "port_range_max": 443},
+            {"description": "E2E Test Ingress IPv6/TCP HTTPS rule", "direction": "ingress",
+                "ethertype": "IPv6", "protocol": "tcp", "port_range_min": 443, "port_range_max": 443},
+            {"description": "E2E Test Egress IPv6/TCP port range (1024-65525) rule", "direction": "egress",
+             "ethertype": "IPv6", "protocol": "tcp", "port_range_min": 1024, "port_range_max": 65535}
+        ]
+
+        return (remote_prefix_rules, remote_group_rules, icmp_rules, port_range_rules)

--- a/networking_nsxv3/tests/e2e/test_security_groups.py
+++ b/networking_nsxv3/tests/e2e/test_security_groups.py
@@ -1,6 +1,7 @@
 import eventlet
 eventlet.monkey_patch()
 
+from networking_nsxv3.common import config  # noqa
 from neutronclient.common.exceptions import NotFound
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
 import random
@@ -10,8 +11,6 @@ import uuid
 import os
 from networking_nsxv3.tests.e2e import base
 from novaclient.v2.servers import Server
-
-from networking_nsxv3.common import config  # noqa
 
 LOG = logging.getLogger(__name__)
 

--- a/networking_nsxv3/tests/e2e/test_security_groups.py
+++ b/networking_nsxv3/tests/e2e/test_security_groups.py
@@ -45,11 +45,11 @@ class TestSecurityGroups(base.E2ETestCase):
         random_remote = []
         if self.test_sgs:
             if len(self.test_sgs) > 0:
-                random_remote.append({"description": "E2E Test Random Remote Ingress IPv64/TCP rule with remote group", "direction": "ingress",
+                random_remote.append({"description": "E2E Test Random Remote Ingress IPv4/TCP rule with remote group", "direction": "ingress",
                                       "ethertype": "IPv4", "protocol": "tcp", "remote_group_id": random.choice(self.test_sgs)['id']})
-            if len(self.test_sgs) > 1:
-                random_remote.append({"description": "E2E Test Random Remote Ingress IPv64/TCP rule with remote group", "direction": "ingress",
-                                      "ethertype": "IPv4", "protocol": "tcp", "remote_group_id": random.choice(self.test_sgs)['id']})
+            if len(self.test_sgs) > 2:
+                random_remote.append({"description": "E2E Test Random Remote Ingress IPv6/TCP rule with remote group", "direction": "ingress",
+                                      "ethertype": "IPv6", "protocol": "tcp", "remote_group_id": random.choice(self.test_sgs)['id']})
 
         remote_group_rules = [
             {"description": "E2E Test Egress IPv4/UDP rule with remote group", "direction": "egress",

--- a/networking_nsxv3/tests/e2e/test_transport_zone.py
+++ b/networking_nsxv3/tests/e2e/test_transport_zone.py
@@ -1,9 +1,7 @@
 import eventlet
-
 eventlet.monkey_patch()
 
 import os
-
 from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_cache import core as cache
@@ -42,6 +40,8 @@ class TestTransportZoneCaching(base.BaseTestCase):
 
     def setUp(self):
         super(TestTransportZoneCaching, self).setUp()
+        self.skipTest("Skipping test temporarily.")
+
         client = client_nsx.Client()
 
         print(self.transport_zone_name)

--- a/networking_nsxv3/tests/e2e/test_transport_zone.py
+++ b/networking_nsxv3/tests/e2e/test_transport_zone.py
@@ -1,11 +1,11 @@
 import eventlet
 eventlet.monkey_patch()
 
+from networking_nsxv3.common import config # noqa
 import os
 from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_cache import core as cache
-from networking_nsxv3.common import config
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import client_nsx
 from neutron.tests import base
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import Provider

--- a/networking_nsxv3/tests/e2e/test_trunk.py
+++ b/networking_nsxv3/tests/e2e/test_trunk.py
@@ -1,0 +1,76 @@
+import eventlet
+eventlet.monkey_patch()
+
+from novaclient.v2.servers import Server
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
+from networking_nsxv3.tests.e2e import base
+import uuid
+import os
+from oslo_log import log as logging
+
+
+from networking_nsxv3.common import config  # noqa
+
+LOG = logging.getLogger(__name__)
+
+
+class TestTrunk(base.E2ETestCase):
+
+    def __init__(self, *args, **kwds):
+        super().__init__(*args, **kwds)
+        self.test_network1_name = os.environ.get("E2E_NETWORK_NAME", None)
+        self.test_server1_name = os.environ.get("E2E_SERVER_NAME", None)
+
+    def setUp(self):
+        super().setUp()
+        # self.skipTest("Skipping test temporarily.")
+
+        if not self.test_network1_name:
+            self.fail("E2E_NETWORK_NAME is not set. Please set it to the name of the network to use for testing.")
+        if not self.test_server1_name:
+            self.fail("E2E_SERVER_NAME is not set. Please set it to the name of the server to use for testing.")
+
+        # Get the server with the name defined in the class
+        self.set_test_server(self.test_server1_name)
+
+        # Get the network with the name defined in the class
+        self.set_test_network(self.test_network1_name)
+
+        self.trunk_name = f"e2e_test_trunk_{uuid.uuid4()}"
+        self.test_ports = [
+            {"name": "test-trunk-" + str(uuid.uuid4()), "id": None}
+        ]
+
+    def tearDown(self):
+        super().tearDown()
+
+        # Clean up & Assert cleanup
+        LOG.info("Tearing down test case.")
+        self.doCleanups()
+
+    def test_trunk_create_delete(self):
+        # First Create test poty
+        self.create_test_ports()
+
+        # Get the created port from OS
+        self.test_server1_port = self.neutron_client.show_port(self.test_ports[0]['id'])['port']
+
+        # Create Trunk
+        LOG.info(f"Creating Trunk '{self.trunk_name}' with parent port '{self.test_server1_port['id']}'")
+        trunk = self.neutron_client.create_trunk(
+            {'trunk': {'name': self.trunk_name, 'port_id': self.test_server1_port['id']}})
+        self.assertIsNotNone(trunk)
+
+        # Assert Trunk is created
+        trunk1 = self.neutron_client.show_trunk(trunk['trunk']['id'])
+        self.assertIsNotNone(trunk1)
+
+        self.assertEqual("DOWN", trunk1['trunk']['status'], "Trunk status is not DOWN.")
+        self.assertTrue(trunk1['trunk']['admin_state_up'], "Trunk admin state is not UP.")
+
+        # Delete the Trunk
+        LOG.info(f"Deleting Trunk '{self.trunk_name}'")
+        self.neutron_client.delete_trunk(trunk['trunk']['id'])
+        
+        # Assert Trunk is deleted
+        self.assertRaises(Exception, self.neutron_client.show_trunk, trunk['trunk']['id'])

--- a/networking_nsxv3/tests/e2e/test_trunk.py
+++ b/networking_nsxv3/tests/e2e/test_trunk.py
@@ -117,7 +117,7 @@ class TestTrunk(base.E2ETestCase):
         # Assert the server ports participate in the correct security groups in NSX
         LOG.info(
             f"Asserting the server '{self.test_server.name}' ports participate in the correct security groups in NSX.")
-        self.assert_server_nsx_ports_sgs(server_ports)
+        self.assert_os_ports_nsx_sg_membership(server_ports)
 
         # Unattach the parent port from the test server
         LOG.info(
@@ -247,7 +247,7 @@ class TestTrunk(base.E2ETestCase):
 
         # Assert the server ports participate in the correct security groups in NSX
         LOG.info(f"Asserting the server '{server_name}' ports participate in the correct security groups in NSX.")
-        self.assert_server_nsx_ports_sgs(server_ports)
+        self.assert_os_ports_nsx_sg_membership(server_ports)
 
     ###################################################################################
     ###################################################################################

--- a/networking_nsxv3/tests/e2e/test_trunk.py
+++ b/networking_nsxv3/tests/e2e/test_trunk.py
@@ -1,14 +1,13 @@
 import eventlet
 eventlet.monkey_patch()
 
+from networking_nsxv3.common import config  # noqa
 from novaclient.v2.servers import NetworkInterface
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
 from networking_nsxv3.tests.e2e import base
 import uuid
 import os
 from oslo_log import log as logging
-
-from networking_nsxv3.common import config  # noqa
 
 LOG = logging.getLogger(__name__)
 

--- a/networking_nsxv3/tests/e2e/test_trunk.py
+++ b/networking_nsxv3/tests/e2e/test_trunk.py
@@ -1,13 +1,12 @@
 import eventlet
 eventlet.monkey_patch()
 
-from novaclient.v2.servers import Server
+from novaclient.v2.servers import NetworkInterface
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
 from networking_nsxv3.tests.e2e import base
 import uuid
 import os
 from oslo_log import log as logging
-
 
 from networking_nsxv3.common import config  # noqa
 
@@ -38,7 +37,9 @@ class TestTrunk(base.E2ETestCase):
 
         self.trunk_name = f"e2e_test_trunk_{uuid.uuid4()}"
         self.test_ports = [
-            {"name": "test-trunk-" + str(uuid.uuid4()), "id": None}
+            {"name": "e2e-trunk-parent-" + str(uuid.uuid4()), "id": None},
+            {"name": "e2e-trunk-subp1-" + str(uuid.uuid4()), "id": None},
+            {"name": "e2e-trunk-subp2-" + str(uuid.uuid4()), "id": None}
         ]
 
     def tearDown(self):
@@ -49,28 +50,264 @@ class TestTrunk(base.E2ETestCase):
         self.doCleanups()
 
     def test_trunk_create_delete(self):
-        # First Create test poty
+        LOG.info("Testing creating and deleting a trunk.")
+
+        # First Create test ports
+        LOG.info(f"Creating test ports {[p['name'] for p in self.test_ports]}")
         self.create_test_ports()
 
-        # Get the created port from OS
-        self.test_server1_port = self.neutron_client.show_port(self.test_ports[0]['id'])['port']
+        # Create the Trunk
+        trunk = self._create_assert_trunk()
+
+        # Delete the Trunk
+        LOG.info(f"Deleting Trunk '{self.trunk_name}'")
+        self.neutron_client.delete_trunk(trunk['trunk']['id'])
+
+        # Assert Trunk is deleted
+        LOG.info(f"Asserting Trunk '{self.trunk_name}' is deleted.")
+        self.assertRaises(Exception, self.neutron_client.show_trunk, trunk['trunk']['id'])
+
+    def test_attach_detach_trunk(self):
+        LOG.info("Testing attaching and detaching a trunk to a server.")
+
+        # First Create test ports
+        LOG.info(f"Creating test ports {[p['name'] for p in self.test_ports]}")
+        self.create_test_ports()
+
+        # Create the Trunk
+        trunk = self._create_assert_trunk()
+        self.addCleanup(self.neutron_client.delete_trunk, trunk['trunk']['id'])
+
+        # Attach the parent port to the test server
+        LOG.info(f"Attaching trunk parent port '{self.trunk_parent_port['id']}' to the server '{self.test_server.id}'")
+        self._attach_port_to_the_server(self.trunk_parent_port['id'])
+
+        # Assert the trunk parent port is attached to the server
+        LOG.info(
+            f"Asserting trunk parent port '{self.trunk_parent_port['id']}' is attached to the server '{self.test_server.id}'")
+        parent_port = self.neutron_client.show_port(self.trunk_parent_port['id'])['port']
+        self.assertEqual(self.test_server.id, parent_port['device_id'],
+                         "Trunk parent port is not attached to the server.")
+        server_ports: list[NetworkInterface] = self.nova_client.servers.interface_list(self.test_server.id)
+        self.assertTrue(any(p.port_id == parent_port['id'] for p in server_ports),
+                        "Trunk parent port is not attached to the server.")
+
+        # Assert port is created in NSX and has the correct attachment details
+        LOG.info(f"Asserting trunk parent port '{parent_port['id']}' is created in NSX.")
+        nsx_port = self.get_nsx_port_by_os_id(parent_port['id'])
+        self.assertIsNotNone(nsx_port)
+        self.assertEqual(parent_port['id'], nsx_port['display_name'], "NSX Port display name is not as expected.")
+        self.assertEqual(parent_port['id'], nsx_port['attachment']['id'], "NSX Port attachment id is not as expected.")
+        self.assertEqual("PARENT", nsx_port['attachment']['type'], "NSX Port attachment type is not as expected.")
+        self.assertEqual(parent_port['binding:vif_details']["segmentation_id"], nsx_port['attachment']['traffic_tag'],
+                         "NSX Port attachment traffic tag is not as expected.")
+
+        # Assert all subports are also created in NSX and have the correct attachment details
+        LOG.info(
+            f"Asserting trunk subports {[ p['port_id'] for p in parent_port['trunk_details']['sub_ports']]} are created in NSX.")
+        for p in parent_port['trunk_details']['sub_ports']:
+            nsx_port = self.get_nsx_port_by_os_id(p['port_id'])
+            self.assertIsNotNone(nsx_port)
+            self.assertEqual(p['port_id'], nsx_port['display_name'], "NSX Port display name is not as expected.")
+            self.assertEqual(p['port_id'], nsx_port['attachment']['id'], "NSX Port attachment id is not as expected.")
+            self.assertEqual("CHILD", nsx_port['attachment']['type'], "NSX Port attachment type is not as expected.")
+            self.assertEqual(p['segmentation_id'], nsx_port['attachment']['traffic_tag'],
+                             "NSX Port attachment traffic tag is not as expected.")
+
+        # Assert the server ports participate in the correct security groups in NSX
+        LOG.info(
+            f"Asserting the server '{self.test_server.name}' ports participate in the correct security groups in NSX.")
+        self.assert_server_nsx_ports_sgs(server_ports)
+
+        # Unattach the parent port from the test server
+        LOG.info(
+            f"Unattaching trunk parent port '{parent_port['id']}' from the server '{self.test_server.id}'")
+        self.nova_client.servers.interface_detach(self.test_server.id, parent_port['id'])
+        eventlet.sleep(5)
+
+        # Assert the trunk parent port is unattached from the server and is unbound
+        LOG.info(
+            f"Asserting trunk parent port '{parent_port['id']}' is unattached from the server '{self.test_server.id}' and is unbound.")
+        parent_port = self.neutron_client.show_port(parent_port['id'])['port']
+        self.assertFalse(bool(parent_port['device_id']), "Trunk parent port is still attached to the server.")
+        self.assertEqual('unbound', parent_port['binding:vif_type'], "Trunk parent port is still bound to host.")
+        self.assertEqual({}, parent_port['binding:vif_details'], "Trunk parent port is still bound to host.")
+
+    def test_add_remove_trunk_subports(self):
+        LOG.info("Testing adding and removing subports to a trunk.")
+
+        # First Create test ports
+        LOG.info(f"Creating test ports {[p['name'] for p in self.test_ports]}")
+        self.create_test_ports()
+
+        # Create the Trunk
+        trunk = self._create_assert_trunk()
+        self.addCleanup(self.neutron_client.delete_trunk, trunk['trunk']['id'])
+
+        # Attach the parent port to the test server
+        self._attach_port_to_the_server(self.trunk_parent_port['id'])
+
+        # Add a new subport
+        new_port = self.create_new_port()
+        self.neutron_client.trunk_add_subports(trunk['trunk']['id'], {
+            'sub_ports': [{'port_id': new_port['id'], 'segmentation_type': 'vlan', 'segmentation_id': 300}]
+        })
+
+        # Assert the new subport is added to the trunk
+        trunk1 = self.neutron_client.show_trunk(trunk['trunk']['id'])
+        self.assertIsNotNone(trunk1)
+        t = trunk1['trunk']
+        self.assertEqual(3, len(t['sub_ports']), "Trunk subports count is not as expected.")
+        self.assertEqual(new_port['id'], t['sub_ports'][2]['port_id'], "Trunk subport is not as expected.")
+
+        # Assert the new subport is attached to the server
+        new_port = self.neutron_client.show_port(new_port['id'])['port']
+        self.assertEqual(self.test_server.id, new_port['device_id'], "Trunk subport is not attached to the server.")
+
+        # Assert the new subport is created in NSX and has the correct attachment details
+        nsx_port = self.get_nsx_port_by_os_id(new_port['id'])
+        self.assertIsNotNone(nsx_port)
+        self.assertEqual(new_port['id'], nsx_port['display_name'], "NSX Port display name is not as expected.")
+
+        # Remove the new subport
+        self.neutron_client.trunk_remove_subports(trunk['trunk']['id'], {
+            'sub_ports': [{'port_id': new_port['id']}]
+        })
+
+        # Assert the new subport is removed from the trunk
+        trunk2 = self.neutron_client.show_trunk(trunk['trunk']['id'])
+        self.assertIsNotNone(trunk2)
+        t = trunk2['trunk']
+        self.assertEqual(2, len(t['sub_ports']), "Trunk subports count is not as expected.")
+        self.assertNotEqual(new_port['id'], t['sub_ports'][0]['port_id'], "Trunk subport is not removed.")
+        self.assertNotEqual(new_port['id'], t['sub_ports'][1]['port_id'], "Trunk subport is not removed.")
+
+        # Assert the new subport is unattached from the server and is unbound
+        new_port = self.neutron_client.show_port(new_port['id'])['port']
+        self.assertFalse(bool(new_port['device_id']), "Trunk subport is still attached to the server.")
+        self.assertEqual('unbound', new_port['binding:vif_type'], "Trunk subport is still bound to host.")
+        self.assertEqual({}, new_port['binding:vif_details'], "Trunk subport is still bound to host.")
+
+    def test_create_server_with_trunk(self):
+        LOG.info("Testing creating a server with a trunk.")
+
+        # First Create test ports
+        LOG.info(f"Creating test ports {[p['name'] for p in self.test_ports]}")
+        self.create_test_ports()
+
+        # Create the Trunk
+        trunk = self._create_assert_trunk()
+        self.addCleanup(self.neutron_client.delete_trunk, trunk['trunk']['id'])
+
+        # Create a new server with the trunk
+        server_name = os.environ.get("E2E_CREATE_SERVER_NAME_PREFIX", "os-e2e-test-") + str(uuid.uuid4())
+        img_name = os.environ.get("E2E_CREATE_SERVER_IMAGE_NAME", "cirros-0.3.2-i386-disk")
+        flvr_name = os.environ.get("E2E_CREATE_SERVER_FLAVOR_NAME", "m1.nano")
+        sg_name = "default"
+
+        LOG.info(f"Creating server '{server_name}' with\n"
+                 f" - trunk: '{self.trunk_name}'\n"
+                 f" - image: '{img_name}'\n"
+                 f" - flavor: '{flvr_name}'\n"
+                 f" - security group: '{sg_name}'")
+
+        server = self.create_test_server(name=server_name,
+                                         image_name=img_name,
+                                         flavor_name=flvr_name,
+                                         security_groups=[sg_name],
+                                         nic_ports=[{
+                                             "port-id": self.trunk_parent_port['id'],
+                                             "net-id": self.trunk_parent_port['network_id']
+                                         }])
+        self.addCleanup(self.nova_client.servers.delete, server.id)
+
+        # Assert the server is created
+        server1 = self.nova_client.servers.get(server.id)
+        self.assertIsNotNone(server1)
+
+        # Assert the server has the correct trunk attached
+        LOG.info(f"Asserting server '{server_name}' has trunk '{self.trunk_name}' attached.")
+        server_ports = self.nova_client.servers.interface_list(server.id)
+        self.assertTrue(any(p.port_id == self.trunk_parent_port['id'] for p in server_ports),
+                        "Trunk parent port is not attached to the server.")
+        self.assertTrue(any(p.port_id == self.trunk_child_ports[0]['id'] for p in server_ports),
+                        "Trunk subport1 is not attached to the server.")
+        self.assertTrue(any(p.port_id == self.trunk_child_ports[1]['id'] for p in server_ports),
+                        "Trunk subport2 is not attached to the server.")
+
+        # Assert the server ports are created in NSX and have the correct attachment details
+        LOG.info(f"Asserting server '{server_name}' ports are created in NSX.")
+        for p in server_ports:
+            nsx_port = self.get_nsx_port_by_os_id(p.port_id)
+            self.assertIsNotNone(nsx_port)
+            self.assertEqual(p.port_id, nsx_port['display_name'], "NSX Port display name is not as expected.")
+            self.assertEqual(p.port_id, nsx_port['attachment']['id'], "NSX Port attachment id is not as expected.")
+            self.assertEqual("PARENT" if p.port_id == self.trunk_parent_port['id'] else "CHILD",
+                             nsx_port['attachment']['type'], "NSX Port attachment type is not as expected.")
+
+        # Assert the server ports participate in the correct security groups in NSX
+        LOG.info(f"Asserting the server '{server_name}' ports participate in the correct security groups in NSX.")
+        self.assert_server_nsx_ports_sgs(server_ports)
+
+    ###################################################################################
+    ###################################################################################
+
+    def _attach_port_to_the_server(self, port_id: str):
+        """ Attach the port (port_id) to the test server (self.test_server).
+        """
+        self.nova_client.servers.interface_attach(
+            server=self.test_server.id,
+            port_id=port_id,
+            net_id=None,
+            fixed_ip=None
+        )
+
+    def _create_assert_trunk(self) -> dict:
+        """ Create a trunk and assert its properties. The ports are not attached to any VM.
+            :return: The created trunk
+        """
+        # Get the created ports from OpenStack
+        self.trunk_parent_port = self.neutron_client.show_port(self.test_ports[0]['id'])['port']
+        self.trunk_child_ports = [self.neutron_client.show_port(port['id'])['port'] for port in self.test_ports[1:]]
 
         # Create Trunk
-        LOG.info(f"Creating Trunk '{self.trunk_name}' with parent port '{self.test_server1_port['id']}'")
-        trunk = self.neutron_client.create_trunk(
-            {'trunk': {'name': self.trunk_name, 'port_id': self.test_server1_port['id']}})
+        LOG.info(f"Creating Trunk '{self.trunk_name}' with parent port '{self.trunk_parent_port['id']}' "
+                 f"and subports '{[p['id'] for p in self.trunk_child_ports]}'")
+        trunk = self.neutron_client.create_trunk({
+            'trunk': {
+                'name': self.trunk_name,
+                'port_id': self.trunk_parent_port['id'],
+                'sub_ports': [
+                    {'port_id': self.trunk_child_ports[0]['id'], 'segmentation_type': 'vlan', 'segmentation_id': 100},
+                    {'port_id': self.trunk_child_ports[1]['id'], 'segmentation_type': 'vlan', 'segmentation_id': 200}
+                ]
+            }
+        })
         self.assertIsNotNone(trunk)
 
         # Assert Trunk is created
         trunk1 = self.neutron_client.show_trunk(trunk['trunk']['id'])
         self.assertIsNotNone(trunk1)
 
-        self.assertEqual("DOWN", trunk1['trunk']['status'], "Trunk status is not DOWN.")
-        self.assertTrue(trunk1['trunk']['admin_state_up'], "Trunk admin state is not UP.")
+        expected_child1 = self.trunk_child_ports[0]
+        expected_child2 = self.trunk_child_ports[1]
+        t = trunk1['trunk']
+        trunk_child1 = t['sub_ports'][0]
+        trunk_child2 = t['sub_ports'][1]
 
-        # Delete the Trunk
-        LOG.info(f"Deleting Trunk '{self.trunk_name}'")
-        self.neutron_client.delete_trunk(trunk['trunk']['id'])
-        
-        # Assert Trunk is deleted
-        self.assertRaises(Exception, self.neutron_client.show_trunk, trunk['trunk']['id'])
+        self.assertEqual("DOWN", t['status'], "Trunk status is not DOWN.")
+        self.assertTrue(t['admin_state_up'], "Trunk admin state is not UP.")
+        self.assertEqual(self.trunk_name, t['name'], "Trunk name is not as expected.")
+        self.assertEqual(self.trunk_parent_port['id'], t['port_id'], "Trunk parent port is not as expected.")
+        self.assertEqual(2, len(t['sub_ports']), "Trunk subports count is not as expected.")
+        self.assertEqual(expected_child1['id'], trunk_child1['port_id'], "Trunk subport1 is not as expected.")
+        self.assertEqual(100, trunk_child1['segmentation_id'], "Trunk subport1 segmentation id is not as expected.")
+        self.assertEqual(expected_child2['id'], trunk_child2['port_id'], "Trunk subport2 is not as expected.")
+        self.assertEqual(200, trunk_child2['segmentation_id'], "Trunk subport2 segmentation id is not as expected.")
+
+        # Assert trunk ports are not created in NSX as they are not attached to any VM
+        LOG.info(f"Asserting trunk ports are not created in NSX as they are not attached to any VM")
+        for port in self.test_ports:
+            nsx_port = self.get_nsx_port_by_os_id(port['id'])
+            self.assertIsNone(nsx_port)
+        return trunk

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ setenv = VIRTUAL_ENV={envdir}
          E2E_CREATE_SERVER_NAME_PREFIX={env:E2E_CREATE_SERVER_NAME_PREFIX:}
          E2E_CREATE_SERVER_IMAGE_NAME={env:E2E_CREATE_SERVER_IMAGE_NAME:}
          E2E_CREATE_SERVER_FLAVOR_NAME={env:E2E_CREATE_SERVER_FLAVOR_NAME:}
+         E2E_BB={env:E2E_BB:}
 
 
 deps = -c{env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/yoga-m3/upper-constraints.txt}

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,9 @@ setenv = VIRTUAL_ENV={envdir}
          OS_PROJECT_DOMAIN_ID={env:OS_PROJECT_DOMAIN_ID:}
          OS_USER_DOMAIN_ID={env:OS_USER_DOMAIN_ID:}
          OS_HOSTNAME={env:OS_HOSTNAME:}
-         OS_HTTPS={env:OS_HTTPS:true}
+         OS_HTTPS={env:OS_HTTPS:1}
+         E2E_NETWORK_NAME={env:E2E_NETWORK_NAME:}
+         E2E_SERVER_NAME={env:E2E_SERVER_NAME:}
 
 
 deps = -c{env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/yoga-m3/upper-constraints.txt}

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,9 @@ setenv = VIRTUAL_ENV={envdir}
          OS_HTTPS={env:OS_HTTPS:1}
          E2E_NETWORK_NAME={env:E2E_NETWORK_NAME:}
          E2E_SERVER_NAME={env:E2E_SERVER_NAME:}
+         E2E_CREATE_SERVER_NAME_PREFIX={env:E2E_CREATE_SERVER_NAME_PREFIX:}
+         E2E_CREATE_SERVER_IMAGE_NAME={env:E2E_CREATE_SERVER_IMAGE_NAME:}
+         E2E_CREATE_SERVER_FLAVOR_NAME={env:E2E_CREATE_SERVER_FLAVOR_NAME:}
 
 
 deps = -c{env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/yoga-m3/upper-constraints.txt}


### PR DESCRIPTION
# End-to-End Test Scenarios

## Ports E2E Tests
   - Create/Delete a standalone port [implemented]
   - Attach/Detach port to/from VM [implemented]
   - Create server (auto-create port) [implemented]
   - Assign/Unassign IPv4/IPv6 address [implemented]
## QOS E2E Tests
   - Create/Delete QoS Policy [implemented]
   - Assign/Remove QoS Policy to/from port [partially] (depends on https://github.com/sapcc/networking-nsx-t/pull/135)
## Trunk E2E Tests
   - Create/Delete trunk [implemented]
   - Add/Remove ports to/from trunk [implemented]
   - Add/Remove trunk to/from server [implemented]
   - Provision server with trunk [implemented]
## Security Groups & Policies
   - Create/Delete/Update Security Groups (Remote IP) [implemented]
   - Create/Delete/Update Security Groups (Remote Group) [implemented]
   - Add/Remove rules to Security Groups [implemented]
   - Add/Remove ports to/from Security Group [implemented]
## Address Groups
   - Create/Delete/Update IPv4/IPv6 address groups [implemented]
   - Create mixed IPv4/IPv6 members [implemented]
   - Address group in multiple security groups [implemented]