### PR TITLE
Register DEFAULT group on agent start

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
@@ -306,6 +306,7 @@ class NSXv3Manager(amb.CommonAgentManagerBase):
 
 
 def main():
+    common_config.register_common_config_options()
     common_config.init(sys.argv[1:])
     common_config.setup_logging()
     agent_config.register_agent_state_opts_helper(cfg.CONF)

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/cli.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/cli.py
@@ -305,6 +305,7 @@ class CLI(object):
         for file in args.config_file:
             neutron_config.extend(["--config-file", file])
 
+        common_config.register_common_config_options()
         common_config.init(neutron_config)
         common_config.setup_logging()
         profiler.setup(nsxv3_constants.NSXV3_BIN, cfg.CONF.host)


### PR DESCRIPTION
From upstream commit 4d3a2747 fixing bug (#1968606), registration of the group DEFAULT does not happen automatically anymore.

If not loaded, agent fails with 'oslo_config.cfg.NoSuchOptError: no such option base_mac in group [DEFAULT]