### PR TITLE
[Caracal] Migrate github workflow and Fix Tests

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -9,20 +9,20 @@ on:
 
 env:
   UPPER_CONSTRAINTS_FILE: https://raw.githubusercontent.com/sapcc/requirements/stable/2024.1-m3/upper-constraints.txt
-  VIRTUALENV_PIP: "20.2.3"
+  #VIRTUALENV_PIP: "20.2.3"
 
 jobs:
   build:
 
-    #runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
     #issue https://github.com/actions/setup-python/issues/544i
-    runs-on: ubuntu-20.04
+    #runs-on: ubuntu-20.04
     permissions:
       pull-requests: write
     strategy:
       fail-fast: false
       matrix:
-        python: [3.10]
+        python: ['3.10']
         tox-env: [coverage]
     env:
       TOXENV: ${{ matrix.tox-env }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -5,10 +5,10 @@ name: Coverage
 
 on:
   pull_request:
-    branches: [ stable/yoga-m3 ]
+    branches: [ stable/2024.1-m3 ]
 
 env:
-  UPPER_CONSTRAINTS_FILE: https://raw.githubusercontent.com/sapcc/requirements/stable/yoga-m3/upper-constraints.txt
+  UPPER_CONSTRAINTS_FILE: https://raw.githubusercontent.com/sapcc/requirements/stable/2024.1-m3/upper-constraints.txt
   VIRTUALENV_PIP: "20.2.3"
 
 jobs:
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.8.14]
+        python: [3.10]
         tox-env: [coverage]
     env:
       TOXENV: ${{ matrix.tox-env }}

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -5,12 +5,12 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ stable/yoga-m3 ]
+    branches: [ stable/2024.1-m3 ]
   pull_request:
-    branches: [ stable/yoga-m3 ]
+    branches: [ stable/2024.1-m3 ]
 
 env:
-  UPPER_CONSTRAINTS_FILE: https://raw.githubusercontent.com/sapcc/requirements/stable/yoga-m3/upper-constraints.txt
+  UPPER_CONSTRAINTS_FILE: https://raw.githubusercontent.com/sapcc/requirements/stable/2024.1-m3/upper-constraints.txt
   VIRTUALENV_PIP: "20.2.3"
 
 jobs:
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.8.14]
+        python: [3.10]
         tox-env: [unit,pep8,pip-missing-reqs]
     env:
       TOXENV: ${{ matrix.tox-env }}

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -11,17 +11,17 @@ on:
 
 env:
   UPPER_CONSTRAINTS_FILE: https://raw.githubusercontent.com/sapcc/requirements/stable/2024.1-m3/upper-constraints.txt
-  VIRTUALENV_PIP: "20.2.3"
+  #VIRTUALENV_PIP: "20.2.3"
 
 jobs:
   build:
 
-    #runs-on: ubuntu-latest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    #runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        python: [3.10]
+        python: ['3.10']
         tox-env: [unit,pep8,pip-missing-reqs]
     env:
       TOXENV: ${{ matrix.tox-env }}

--- a/networking_nsxv3/db/db.py
+++ b/networking_nsxv3/db/db.py
@@ -166,7 +166,8 @@ def get_port(context, host, port_id):
         PortBinding.vif_details,
         PortBinding.status
     ).join(
-        StandardAttribute,
+        StandardAttribute
+    ).join(
         PortBinding
     ).filter(
         Port.id == port_id,

--- a/networking_nsxv3/db/db.py
+++ b/networking_nsxv3/db/db.py
@@ -13,11 +13,13 @@ from neutron.db.qos.models import (QosBandwidthLimitRule, QosDscpMarkingRule,
 from neutron.plugins.ml2.models import PortBinding, PortBindingLevel
 from neutron.services.trunk import models as trunk_model
 from neutron_lib.api.definitions import portbindings
+from neutron_lib.db import api as db_api
 from neutron_lib.db.standard_attr import StandardAttribute
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import text
 
 
+@db_api.CONTEXT_READER
 def get_ports_with_revisions(context, host, limit, cursor):
     return context.session.query(
         Port.id,
@@ -38,6 +40,7 @@ def get_ports_with_revisions(context, host, limit, cursor):
     ).all()
 
 
+@db_api.CONTEXT_READER
 def get_qos_policies_with_revisions(context, host, limit, cursor):
     return context.session.query(
         QosPolicy.id,
@@ -62,6 +65,7 @@ def get_qos_policies_with_revisions(context, host, limit, cursor):
     ).all()
 
 
+@db_api.CONTEXT_READER
 def get_security_groups_with_revisions(context, host, limit, cursor):
     return context.session.query(
         sg_db.SecurityGroup.id,
@@ -86,6 +90,7 @@ def get_security_groups_with_revisions(context, host, limit, cursor):
     ).all()
 
 
+@db_api.CONTEXT_READER
 def get_security_group_revision(context, security_group_id):
     return context.session.query(
         sg_db.SecurityGroup.id,
@@ -98,6 +103,7 @@ def get_security_group_revision(context, security_group_id):
     ).one_or_none()
 
 
+@db_api.CONTEXT_READER
 def get_security_group_tag(context, security_group_id):
     return context.session.query(
         tag_model.Tag.tag
@@ -109,6 +115,7 @@ def get_security_group_tag(context, security_group_id):
     ).all()
 
 
+@db_api.CONTEXT_READER
 def get_qos(context, qos_id):
     return context.session.query(
         QosPolicy.name,
@@ -120,6 +127,7 @@ def get_qos(context, qos_id):
     ).one_or_none()
 
 
+@db_api.CONTEXT_READER
 def get_qos_ports_by_host(context, host, qos_id):
     return context.session.query(
         Port.id,
@@ -136,6 +144,7 @@ def get_qos_ports_by_host(context, host, qos_id):
     ).limit(1).one_or_none()
 
 
+@db_api.CONTEXT_READER
 def get_qos_bwl_rules(context, qos_id):
     return context.session.query(
         QosBandwidthLimitRule.direction,
@@ -146,6 +155,7 @@ def get_qos_bwl_rules(context, qos_id):
     ).all()
 
 
+@db_api.CONTEXT_READER
 def get_qos_dscp_rules(context, qos_id):
     return context.session.query(
         QosDscpMarkingRule.qos_policy_id,
@@ -155,6 +165,7 @@ def get_qos_dscp_rules(context, qos_id):
     ).all()
 
 
+@db_api.CONTEXT_READER
 def get_port(context, host, port_id):
     port = context.session.query(
         Port.id,
@@ -223,6 +234,7 @@ def get_port(context, host, port_id):
     }
 
 
+@db_api.CONTEXT_READER
 def get_port_security_groups(context, port_id):
     return context.session.query(
         sg_db.SecurityGroupPortBinding.security_group_id
@@ -231,6 +243,7 @@ def get_port_security_groups(context, port_id):
     ).all()
 
 
+@db_api.CONTEXT_READER
 def get_port_allowed_pairs(context, port_id):
     return context.session.query(
         allowed_address_pair.AllowedAddressPair.ip_address,
@@ -240,6 +253,7 @@ def get_port_allowed_pairs(context, port_id):
     ).all()
 
 
+@db_api.CONTEXT_READER
 def get_port_addresses(context, port_id):
     return context.session.query(
         IPAllocation.ip_address
@@ -248,6 +262,7 @@ def get_port_addresses(context, port_id):
     ).all()
 
 
+@db_api.CONTEXT_READER
 def get_rules_for_security_group_id(context, security_group_id):
     return context.session.query(
         sg_db.SecurityGroupRule
@@ -256,6 +271,7 @@ def get_rules_for_security_group_id(context, security_group_id):
     ).all()
 
 
+@db_api.CONTEXT_READER
 def get_port_id_by_sec_group_id(context, host, security_group_id):
     result = context.session.query(
         sg_db.SecurityGroupPortBinding.port_id
@@ -271,6 +287,7 @@ def get_port_id_by_sec_group_id(context, host, security_group_id):
     return [o[0] for o in result]
 
 
+@db_api.CONTEXT_READER
 def get_security_groups_for_host(context, host, limit, cursor):
     return context.session.query(
         sg_db.SecurityGroupPortBinding.security_group_id,
@@ -287,6 +304,7 @@ def get_security_groups_for_host(context, host, limit, cursor):
     ).distinct().limit(limit).all()
 
 
+@db_api.CONTEXT_READER
 def get_remote_security_groups_for_host(context, host, limit, cursor):
     return context.session.query(
         sg_db.SecurityGroupRule.remote_group_id,
@@ -307,6 +325,7 @@ def get_remote_security_groups_for_host(context, host, limit, cursor):
     ).distinct().limit(limit).all()
 
 
+@db_api.CONTEXT_READER
 def has_security_group_used_by_host(context, host, security_group_id):
     if context.session.query(
         sg_db.SecurityGroup.id
@@ -341,6 +360,7 @@ def has_security_group_used_by_host(context, host, security_group_id):
     return False
 
 
+@db_api.CONTEXT_READER
 def get_security_group_members_ips(context, security_group_id):
     port_id = sg_db.SecurityGroupPortBinding.port_id
     group_id = sg_db.SecurityGroupPortBinding.security_group_id
@@ -354,6 +374,7 @@ def get_security_group_members_ips(context, security_group_id):
     ).all()
 
 
+@db_api.CONTEXT_READER
 def get_security_group_port_ids(context, host, security_group_id):
     ses: Session = context.session
     res = ses.query(
@@ -386,6 +407,7 @@ def get_security_group_port_ids(context, host, security_group_id):
     return ports_with_sg_count
 
 
+@db_api.CONTEXT_READER
 def get_security_group_members_address_bindings_ips(context, security_group_id):
     port_id = sg_db.SecurityGroupPortBinding.port_id
     group_id = sg_db.SecurityGroupPortBinding.security_group_id
@@ -399,6 +421,7 @@ def get_security_group_members_address_bindings_ips(context, security_group_id):
     ).all()
 
 
+@db_api.CONTEXT_READER
 def get_port_logging(context, port_id):
     return context.session.query(
         Log.project_id,
@@ -409,6 +432,7 @@ def get_port_logging(context, port_id):
     ).one_or_none()
 
 
+@db_api.CONTEXT_READER
 def has_security_group_logging(context, security_group_id):
     result = context.session.query(
         Log.resource_id,
@@ -420,6 +444,7 @@ def has_security_group_logging(context, security_group_id):
     return True if result else False
 
 
+@db_api.CONTEXT_READER
 def get_addresses_for_address_group_id(context, addr_group_id):
     return context.session.query(
         ag_db.AddressAssociation.address
@@ -428,6 +453,7 @@ def get_addresses_for_address_group_id(context, addr_group_id):
     ).all()
 
 
+@db_api.CONTEXT_READER
 def get_address_group_revision_number(context, addr_group_id):
     return context.session.query(
         StandardAttribute.revision_number

--- a/networking_nsxv3/db/db.py
+++ b/networking_nsxv3/db/db.py
@@ -403,8 +403,7 @@ def get_security_group_port_ids(context, host, security_group_id):
         "GROUP BY port_id"
     )
 
-    ports_with_sg_count = ses.execute(sql)
-    return ports_with_sg_count
+    return [row._mapping for row in ses.execute(sql)]
 
 
 @db_api.CONTEXT_READER

--- a/networking_nsxv3/extensions/nsxtoperations.py
+++ b/networking_nsxv3/extensions/nsxtoperations.py
@@ -14,7 +14,13 @@ from neutron_lib.api import extensions as api_extensions
 from neutron_lib.plugins import constants as plugin_constants
 from neutron_lib.plugins import directory
 from neutron import policy
-from neutron import wsgi
+
+try:
+    from neutron.api import wsgi
+except ImportError:
+    from neutron import wsgi
+
+
 from webob import exc as web_exc
 from webob import exc as exceptions
 from oslo_log import log

--- a/networking_nsxv3/extensions/nsxtoperations.py
+++ b/networking_nsxv3/extensions/nsxtoperations.py
@@ -3,6 +3,10 @@ import json
 import importlib
 import functools
 
+#Load common config here, as registering the api extension fails without
+from neutron.common import config
+config.register_common_config_options()
+
 from neutron import policy
 from neutron.api import extensions
 from neutron.api.v2.resource import Resource

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
@@ -306,9 +306,12 @@ class NSXv3Manager(amb.CommonAgentManagerBase):
 
 
 def main():
+    logging.register_options(cfg.CONF)
+    common_config.register_common_config_options()
+    agent_config.register_agent_state_opts_helper(cfg.CONF)
+
     common_config.init(sys.argv[1:])
     common_config.setup_logging()
-    agent_config.register_agent_state_opts_helper(cfg.CONF)
     profiler.setup(nsxv3_constants.NSXV3_BIN, cfg.CONF.host)
     LOG.info("VMware NSXv3 Agent initializing ...")
 

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
@@ -9,6 +9,7 @@ from typing import Callable
 import oslo_messaging
 from neutron.common import config as common_config
 from neutron.common import profiler
+from neutron.conf import service as service_conf
 from neutron.plugins.ml2.drivers.agent import _agent_manager_base as amb
 from neutron.plugins.ml2.drivers.agent import _common_agent as ca
 from oslo_config import cfg
@@ -306,13 +307,14 @@ class NSXv3Manager(amb.CommonAgentManagerBase):
 
 
 def main():
-    logging.register_options(cfg.CONF)
     common_config.register_common_config_options()
+    common_config.init(sys.argv[1:])
+
+    common_config.setup_logging()
     agent_config.register_agent_state_opts_helper(cfg.CONF)
 
-    common_config.init(sys.argv[1:])
-    common_config.setup_logging()
     profiler.setup(nsxv3_constants.NSXV3_BIN, cfg.CONF.host)
+    service_conf.register_service_opts(service_conf.RPC_EXTRA_OPTS, cfg.CONF)
     LOG.info("VMware NSXv3 Agent initializing ...")
 
     try:

--- a/networking_nsxv3/tests/unit/db/test_db.py
+++ b/networking_nsxv3/tests/unit/db/test_db.py
@@ -259,6 +259,5 @@ class TestAgentsDbBase(testlib_api.SqlTestCase):
             self.assertEqual(self.sg_id_1, sgs_for_h[0])
         self.assertEqual(1, len(sg_ips))
         self.assertEqual("192.168.0.100", sg_ips[0][0])
-        rows = [r for r in sg_port_ids]
-        self.assertEqual(1, len(rows))
-        self.assertEqual(self.port_id_1, rows[0][0])
+        self.assertEqual(1, len(sg_port_ids))
+        self.assertEqual(self.port_id_1, sg_port_ids[0]['port_id'])

--- a/networking_nsxv3/tests/unit/db/test_db.py
+++ b/networking_nsxv3/tests/unit/db/test_db.py
@@ -7,11 +7,11 @@ from neutron.db import models_v2
 
 from neutron.plugins.ml2 import models as ml2_models
 from neutron.tests.unit import testlib_api
-from sqlalchemy.orm.session import Session
 from networking_nsxv3.common import constants as nsxv3_constants
 from neutron.db.qos.models import (QosPolicy, QosPortPolicyBinding)
 from neutron.services.trunk import models as trunk_model
 from neutron.db.models import securitygroup as sg_model
+from neutron_lib.db import api as db_api
 
 from networking_nsxv3.db import db
 
@@ -24,7 +24,6 @@ class TestAgentsDbBase(testlib_api.SqlTestCase):
     def setUp(self):
         super(TestAgentsDbBase, self).setUp()
         self.ctx = context.get_admin_context()
-        self.session: Session = self.ctx.session
         self.plugin = FakePlugin()
 
         self.tenant_id = 1
@@ -47,23 +46,6 @@ class TestAgentsDbBase(testlib_api.SqlTestCase):
             "shared": False,
             "name": "test_net_1",
             "admin_state_up": True,
-            "description": ""
-        }})
-        self.plugin.create_subnetpool(self.ctx, {"subnetpool": {
-            "tenant_id": self.tenant_id,
-            "id": self.ip_pool_id,
-            "name": "default_test_pool",
-            "prefixes": ["192.168.0.0", "192.168.1.0", "192.168.2.0"],
-            # "min_prefix": 16,
-            "min_prefixlen": 16,
-            # "max_prefix": "",
-            "max_prefixlen": 32,
-            # "default_prefix": "",
-            "default_prefixlen": 32,
-            # "default_quota": "",
-            # "address_scope_id": "",
-            "is_default": True,
-            "shared": True,
             "description": ""
         }})
         self.plugin.create_port(self.ctx, {"port": {
@@ -103,10 +85,10 @@ class TestAgentsDbBase(testlib_api.SqlTestCase):
         subnet = self.plugin.create_subnet(self.ctx, {"subnet": {
             "tenant_id": self.tenant_id,
             "name": "subnet_192_168",
-            "cidr": "192.168.0.0/32",
+            "cidr": "192.168.0.0/28",
             "ip_version": 4,
             "network_id": self.net_id,
-            "subnetpool_id": self.ip_pool_id,
+            #"subnetpool_id": self.ip_pool_id,
             "allocation_pools": [],
             "enable_dhcp": True,
             "dns_nameservers": [],
@@ -155,9 +137,10 @@ class TestAgentsDbBase(testlib_api.SqlTestCase):
             )
         ]
 
-        with self.session.begin(subtransactions=True):
+        self.ctx = context.get_admin_context()
+        with db_api.CONTEXT_WRITER.using(self.ctx):
             for entry in neutron_db:
-                self.session.add(entry)
+                self.ctx.session.add(entry)
 
     def test_get_ports(self):
         port_1 = db.get_port(self.ctx, self.host, self.port_id_1)
@@ -188,8 +171,8 @@ class TestAgentsDbBase(testlib_api.SqlTestCase):
         self.assertEqual(None, port_2)
 
     def test_port_qos(self):
-        with self.session.begin(subtransactions=True):
-            self.session.add(QosPortPolicyBinding(
+        with db_api.CONTEXT_WRITER.using(self.ctx):
+            self.ctx.session.add(QosPortPolicyBinding(
                 policy_id=self.qos_id_1,
                 port_id=self.port_id_1
             ))
@@ -205,19 +188,19 @@ class TestAgentsDbBase(testlib_api.SqlTestCase):
         self.assertEqual(self.port_id_1, qos_port[0])
 
     def test_trunk_port(self):
-        with self.session.begin(subtransactions=True):
-            self.session.add(trunk_model.SubPort(
+        with db_api.CONTEXT_WRITER.using(self.ctx):
+            self.ctx.session.add(trunk_model.SubPort(
                 port_id=self.port_id_2,
                 trunk_id=self.trunk_id_1,
                 segmentation_type="vlan",
                 segmentation_id=11
             ))
-            self.session.add(ml2_models.PortBinding(
+            self.ctx.session.add(ml2_models.PortBinding(
                 port_id=self.port_id_2,
                 host=self.host,
                 vif_type="ovs"
             ))
-            self.session.add(ml2_models.PortBindingLevel(
+            self.ctx.session.add(ml2_models.PortBindingLevel(
                 port_id=self.port_id_2,
                 host=self.host,
                 driver=nsxv3_constants.NSXV3,
@@ -244,8 +227,8 @@ class TestAgentsDbBase(testlib_api.SqlTestCase):
             }, port_2)
 
     def test_port_sgs(self):
-        with self.session.begin(subtransactions=True):
-            self.session.add(sg_model.SecurityGroupPortBinding(
+        with db_api.CONTEXT_WRITER.using(self.ctx):
+            self.ctx.session.add(sg_model.SecurityGroupPortBinding(
                 security_group_id=self.sg_id_1,
                 port_id=self.port_id_1
             ))
@@ -255,6 +238,7 @@ class TestAgentsDbBase(testlib_api.SqlTestCase):
         sg = db.get_security_group_revision(self.ctx, self.sg_id_1)
         port_sgs = db.get_port_security_groups(self.ctx, self.port_id_1)
         port_ids = db.get_port_id_by_sec_group_id(self.ctx, self.host, self.sg_id_1)
+        # Result returns a cartesian product mapping all entries of the StandardAttributes
         sgs_for_host = db.get_security_groups_for_host(self.ctx, self.host, 100, 0)
         sg_ips = db.get_security_group_members_ips(self.ctx, self.sg_id_1)
         sg_port_ids = db.get_security_group_port_ids(self.ctx, self.host, self.sg_id_1)
@@ -270,7 +254,7 @@ class TestAgentsDbBase(testlib_api.SqlTestCase):
         self.assertEqual(self.sg_id_1, port_sgs[0][0])
         self.assertEqual(1, len(port_ids))
         self.assertEqual(self.port_id_1, port_ids[0])
-        self.assertEqual(9, len(sgs_for_host))
+        self.assertEqual(8, len(sgs_for_host))
         for sgs_for_h in sgs_for_host:
             self.assertEqual(self.sg_id_1, sgs_for_h[0])
         self.assertEqual(1, len(sg_ips))

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-neutron>=20.0.0, < 21.0.0 # Apache-2.0
+neutron>=20.0.0 # Apache-2.0
 hacking!=0.13.0,<0.14,>=0.12.0 # Apache-2.0
 coverage!=4.4,>=4.0 # Apache-2.0
 ddt>=1.0.1 # MIT

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ setenv = VIRTUAL_ENV={envdir}
          E2E_CREATE_SERVER_FLAVOR_NAME={env:E2E_CREATE_SERVER_FLAVOR_NAME:}
 
 
-deps = -c{env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/yoga-m3/upper-constraints.txt}
+deps = -c{env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/2024.1-m3/upper-constraints.txt}
        -r{toxinidir}/test-requirements.txt
        -r{toxinidir}/requirements.txt
 
@@ -56,7 +56,7 @@ commands =
     env TEST_OSPROFILER=1 stestr run 'networking_nsxv3.tests.unit'
 
 [testenv:realization]
-basepython = python3.8
+basepython = python3.10
 commands =
     env TEST_OSPROFILER=1 stestr run 'networking_nsxv3.tests.unit.realization'
 
@@ -65,7 +65,7 @@ commands =
     env TEST_OSPROFILER=1 stestr run 'networking_nsxv3.tests.unit.db'
 
 [testenv:coverage]
-basepython = python3.8
+basepython = python3.10
 setenv =
   {[testenv]setenv}
 commands =
@@ -78,15 +78,15 @@ commands =
   bash -c "echo '```' >> pytest-coverage.txt"
 
 [testenv:functional]
-basepython = python3.8
+basepython = python3.10
 commands = env TEST_OSPROFILER=1 pytest networking_nsxv3/tests/functional/
 
 [testenv:e2e]
-basepython = python3.8
+basepython = python3.10
 commands = env TEST_OSPROFILER=1 pytest -s networking_nsxv3/tests/e2e/
 
 [testenv:pep8]
-basepython = python3.8
+basepython = python3.10
 deps = {[testenv]deps}
 commands =
   bash tools/flake8wrap.sh {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -5,17 +5,14 @@
 [tox]
 envlist = unit,functional,pep8,pip-missing-reqs
 skipsdist = True
-requires = virtualenv > v20.8.0
-           setuptools > 58.0.0
+requires = virtualenv >= 20
 
 [testenv]
-basepython = python3
 usedevelop = True
 allowlist_externals = bash
                       find
                       rm
                       env
-install_command = python -m pip install {opts} {packages}
 
 minversion = 3.18.10
 ignore_basepython_conflict = True
@@ -46,17 +43,15 @@ setenv = VIRTUAL_ENV={envdir}
          E2E_CREATE_SERVER_IMAGE_NAME={env:E2E_CREATE_SERVER_IMAGE_NAME:}
          E2E_CREATE_SERVER_FLAVOR_NAME={env:E2E_CREATE_SERVER_FLAVOR_NAME:}
 
-
 deps = -c{env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/2024.1-m3/upper-constraints.txt}
+       -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/2024.1-m3\#egg=neutron}
        -r{toxinidir}/test-requirements.txt
        -r{toxinidir}/requirements.txt
-
 [testenv:unit]
 commands =
     env TEST_OSPROFILER=1 stestr run 'networking_nsxv3.tests.unit'
 
 [testenv:realization]
-basepython = python3.10
 commands =
     env TEST_OSPROFILER=1 stestr run 'networking_nsxv3.tests.unit.realization'
 
@@ -65,7 +60,6 @@ commands =
     env TEST_OSPROFILER=1 stestr run 'networking_nsxv3.tests.unit.db'
 
 [testenv:coverage]
-basepython = python3.10
 setenv =
   {[testenv]setenv}
 commands =
@@ -78,15 +72,12 @@ commands =
   bash -c "echo '```' >> pytest-coverage.txt"
 
 [testenv:functional]
-basepython = python3.10
 commands = env TEST_OSPROFILER=1 pytest networking_nsxv3/tests/functional/
 
 [testenv:e2e]
-basepython = python3.10
 commands = env TEST_OSPROFILER=1 pytest -s networking_nsxv3/tests/e2e/
 
 [testenv:pep8]
-basepython = python3.10
 deps = {[testenv]deps}
 commands =
   bash tools/flake8wrap.sh {posargs}


### PR DESCRIPTION
Change python version and basebranch according to the Caracal release to
version 3.10 and 2024.1-m3.

Loosen constraints for the installation of neutron and
neutron-lib in the test-requirements.txt as the upperbound was set to
Neutron Yoga release. Within the tox configuration request the
installation of yoga from the current stable/2024.1-m3 branch.

For the DB unit tests remove the subnetpool as this is not needed for
a subnet creation. Without the subnetpool, the db unit test test_port_sg
fails as the result of a DB query returns the cartesian product between
the tables SecurityGroupPortBindings and StandardAttributes. Thus the
length of the result set is lowered from 9 to 8.
This is a minor bug which will be fixed in a separate PR.