### PR TITLE
Fix Attribute Error when Metadata is Missing

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
@@ -1136,7 +1136,14 @@ class Provider(base.Provider):
         return outdated, current
 
     def age(self, resource_type: str, os_ids: List[str]):
-        return [(resource_type, id, self.metadata(resource_type, id).age) for id in os_ids]
+        aged_resources = []
+        for id in os_ids:
+            meta_data = self.metadata(resource_type, id)
+            if meta_data:
+                aged_resources.append((resource_type, id, meta_data.age))
+            else:
+                LOG.info("Resource: %s with ID: %s has no metadata", resource_type, id)
+        return aged_resources
 
     # overrides
     def sanitize(self, slice):


### PR DESCRIPTION
In some cases, metadata information (including age) may be missing for an OpenStack ID. Previously, this caused an exception, leading to an aborted sync.

Since the sync is a preventive measure to synchronize objects of a certain age — most likely unchanged from OpenStack's perspective — this commit ensures the process continues even when metadata is absent.

To improve debugging, we now log the resource_type and os_id when metadata is missing.