### PR TITLE
[bugfix] Fixing exception handling in the callback wrapper

### DIFF
--- a/networking_nsxv3/common/synchronization.py
+++ b/networking_nsxv3/common/synchronization.py
@@ -648,8 +648,10 @@ class Runner(object):
                     # greenthread, but this is hidden in the pool, so
                     # let's wrap the function once more.
                     def wrap(rerun: JobRerunner, ajob: Runnable):
-                        ajob.execute()
-                        rerun.job_done(ajob)
+                        try:
+                            ajob.execute()
+                        finally:
+                            rerun.job_done(ajob)
 
                     job.set_scheduled()
                     self._workers.spawn(wrap, self._rerunner, job)


### PR DESCRIPTION
When a callback raises an exception, e.g. because of an error with the NSX-T API, the job will not be rescheduled because the exception will stop the code path.

This happened because during refactoring a try/finally was by accident removed from the outside wrapper that we introduced.