### PR TITLE
[alternative] Fix duplicate segment port creation due to Nova/vSphere/NSX-T race

### DIFF
--- a/networking_nsxv3/exceptions/agent.py
+++ b/networking_nsxv3/exceptions/agent.py
@@ -1,0 +1,10 @@
+
+from neutron_lib._i18n import _
+from neutron_lib import exceptions
+
+class MultipleSegmentPorts(exceptions.NeutronException):
+    message = _("More thant 2 segment ports found for OpenStack Port %(port_id)s")
+
+class NoneUniqueObjectFound(exceptions.NeutronException):
+    message = _("Found multiple objects for query %(query) found for %(objects)s. "
+                "Please use a more specific query to return a single object.")

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
@@ -6,6 +6,7 @@ from requests.exceptions import ConnectionError, ConnectTimeout, HTTPError
 from oslo_utils import versionutils
 from oslo_log import log as logging
 from oslo_config import cfg
+from networking_nsxv3.exceptions.agent import NoneUniqueObjectFound
 from networking_nsxv3.common.synchronization import Scheduler
 from networking_nsxv3.common.locking import LockManager
 import requests
@@ -228,13 +229,10 @@ class Client(metaclass=Singleton):
     def get_unique(self, path: str, params: dict = dict()) -> dict:
         results = self.get(path=path, params=params).json().get("results")
         if isinstance(results, list):
-            if results:
-                if len(results) > 1:
-                    LOG.error("Ambiguous. %s", results)
-                result = results.pop()
-                return result
-        elif results:
-            return results
+            if len(results) > 1:
+                raise NoneUniqueObjectFound(query=params, objects=results)
+            results = results.pop()
+        return results
 
     def search(self, path: str, params: dict) -> dict:
         res = self.get(path=path, params=params)

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
@@ -236,6 +236,13 @@ class Client(metaclass=Singleton):
         elif results:
             return results
 
+    def search(self, path: str, params: dict) -> dict:
+        res = self.get(path=path, params=params)
+        if not res.ok:
+            #ToDo handle errors properly
+            pass
+        return res.json().get("results")
+
     def get_all(self, path: str, params: dict = None, cursor: str = ""):
         # FYI - NSX does not allow to filter by custom property
         # Search API has hard limit of 50k objects (with cursor)

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
@@ -15,6 +15,7 @@ from oslo_log import log as logging
 from oslo_utils import excutils
 from networking_nsxv3.common.constants import *
 from networking_nsxv3.common.locking import LockManager
+from networking_nsxv3.exceptions import agent as agent_exc
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.client_nsx import Client
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import provider as base
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.constants_nsx import *
@@ -914,6 +915,7 @@ class Provider(base.Provider):
         port_id = os_port.get("id")
         port_meta = self.metadata(Provider.PORT, port_id)
 
+
         if delete:
             if not port_meta:
                 LOG.info("Segment Port:%s already deleted.", port_id)
@@ -938,7 +940,25 @@ class Provider(base.Provider):
             provider_port["path"] = port_meta.path
             provider_port["_revision"] = port_meta.revision
         else:
-            LOG.info("Segment Port %s not found, creating...", port_id)
+            LOG.info("Segment Port %s not found, creating ...", port_id)
+            # Workaround Race Condition between NSX-T agent and vSphere
+            # In some cases the vSphere creates the Segment Port before NSX-T agent
+            # NSX-T agent will reuse the existing port, otherwise it will create a new one (default behaviour).
+            duplicate_ports = self.find_duplicate_ports(port_id)
+            if duplicate_ports and len(duplicate_ports) > 0:
+
+                if len(duplicate_ports) > 1:
+                    LOG.error("Found multiple Segment Ports for OpenStack Port %s. Abort binding.", port_id)
+                    raise agent_exc.MultipleSegmentPorts(port_id=port_id)
+
+                existing_segmentport = duplicate_ports[0]
+                LOG.error("Found existing Segment Port %s for OpenStack Port %s.", existing_segmentport["display_name"], port_id)
+                self.metadata_update(Provider.PORT, existing_segmentport)
+
+                port_meta = self.metadata(Provider.PORT, port_id)
+                provider_port["id"] = port_meta.real_id
+                provider_port["path"] = port_meta.path
+                provider_port["_revision"] = port_meta.revision
 
         segment_meta = self.metadata(Provider.NETWORK, os_port.get("vif_details", {}).get("segmentation_id"))
         if not segment_meta:
@@ -967,11 +987,16 @@ class Provider(base.Provider):
                 The port will be added to the security groups as a static member.", port_id, len(port_sgs), max_sg_tags)
             os_port["security_groups"] = None
         return self._realize(Provider.PORT, False, self.payload.segment_port, os_port, provider_port)
+
     def get_port(self, os_id):
         port = self.client.get_unique(path=API.SEARCH_QUERY, params={"query": API.SEARCH_Q_SEG_PORT.format(os_id)})
         if port:
             return self.metadata_update(Provider.PORT, port), port
         return None, None
+
+    def find_duplicate_ports(self, os_port_id):
+        ports = self.client.search(path=API.SEARCH_QUERY, params={"query": API.SEARCH_Q_SEG_PORT.format(os_port_id)})
+        return ports
 
     def get_port_meta_by_ids(self, port_ids: Set[str]) -> Set[PolicyResourceMeta]:
         segment_ports = set()

--- a/networking_nsxv3/tests/unit/test_provider_nsx_policy.py
+++ b/networking_nsxv3/tests/unit/test_provider_nsx_policy.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import copy
 import json
 import re
@@ -1247,3 +1249,131 @@ class TestProviderPolicy(base.BaseTestCase):
 
         vmk_port = requests.get(get_url(api.SEGMENT_PORT.format(vmk_n["id"], vmk_p["id"]))).json()
         self.assertIsNotNone(vmk_port)
+
+    @responses.activate
+    def test_duplicate_segment_port(self):
+
+        vlan = "1000"
+        zone_name = cfg.CONF.NSXV3.nsxv3_transport_zone_name
+        segment_id = str(uuid.uuid5(uuid.NAMESPACE_OID, "1234"))
+        port_id = "53C33142-3607-4CB2-B6E4-FA5F5C9E3C19"
+
+        provider_network = {
+            "type": "DISCONNECTED",
+            "vlan_ids": [
+                vlan
+            ],
+            # "transport_zone_path": API.TRANSPORT_ZONES_PATH.format(tr_zone_id),
+            "advanced_config": {
+                "hybrid": False
+            },
+            "admin_state": "UP",
+            "resource_type": "Segment",
+            "id": segment_id,
+            "display_name": f"{zone_name}-{vlan}",
+            "path": provider_nsx_policy.API.SEGMENT_PATH.format(segment_id),
+            # "_revision": provider_net.get("_revision")
+        }
+
+        os_sg = {
+            "id": "53C33142-3607-4CB2-B6E4-FA5F5C9E3C19",
+            "revision_number": 2,
+            "tags": ["capability_tcp_strict"],
+            "rules": [{
+                "id": "1",
+                "ethertype": "IPv4",
+                "direction": "ingress",
+                "remote_group_id": "",
+                "remote_ip_prefix": "192.168.10.0/24",
+                "security_group_id": "",
+                "port_range_min": "5",
+                "port_range_max": "1",
+                "protocol": "icmp"
+            }]
+        }
+
+        nsxt_agent_port = {
+            "id": port_id,
+            "revision_number": "2",
+            "parent_id": "",
+            "mac_address": "fa:16:3e:e4:11:f1",
+            "admin_state_up": "UP",
+            "address_bindings": ["172.24.4.3", "172.24.4.4"],
+            "security_groups": [os_sg.get("id")],
+            "vif_details": {
+                "nsx-logical-switch-id": segment_id,
+                "segmentation_id": vlan
+            },
+            "_last_modified_time": time.time()
+        }
+
+        #nsxt_agent_port = {
+        #    "id": port_id,
+        #    "display_name": port_id,
+        #    "resource_type": "SegmentPort",
+        #    "admin_state": "UP",
+        #    "attachment": {
+        #        "id": port_id,
+        #        "type": "PARENT",
+        #        "traffic_tag": vlan
+        #    },
+        #    "address_bindings": ["172.24.4.3", "172.24.4.4"],
+        #    "tags": [],
+        #    "parent_path": provider_nsx_policy.API.SEGMENT_PATH.format(segment_id),
+        #    "path": provider_nsx_policy.API.SEGMENT_PORT_PATH.format(segment_id, port_id),
+        #    "_revision": None
+        #}
+
+        vspbere_port = [
+            {
+            "display_name": f"af36b7ba-4cd5-40c4-93cf-c23580329e12.vmx@{port_id}",
+            "resource_type": "SegmentPort",
+            "_create_user": "system",
+            "_create_time": 1751019980231,
+            "parent_path": provider_nsx_policy.API.SEGMENT_PATH.format(segment_id),
+            "path": provider_nsx_policy.API.SEGMENT_PORT_PATH.format(segment_id, "default:17494310-22bc-4e26-ae84-69ba37b9d849"),
+            "attachment": {
+                "hyperbus_mode": "DISABLE",
+                "id": port_id,
+                "traffic_tag": 0
+            },
+            "marked_for_delete": False,
+            "id": "default:17494310-22bc-4e26-ae84-69ba37b9d849"}
+        ]
+
+        # Precreate network and security group
+        requests.put(get_url(provider_nsx_policy.API.SEGMENT.format(
+            provider_network.get("id"))), data=json.dumps(provider_network)).json()
+        provider = provider_nsx_policy.Provider()
+        provider.metadata_refresh(provider_nsx_policy.Provider.NETWORK)
+        provider.sg_rules_realize(os_sg)
+
+        # Mock vpshere created segment port
+        mock = MagicMock(return_value=vspbere_port)
+        provider.find_duplicate_ports = mock
+
+        # Realize NSX-T agent port
+        provider.port_realize(nsxt_agent_port)
+
+        meta_port = provider.metadata(provider.PORT,port_id)
+        expected_id = vspbere_port[0].get("id").split("default:")[1]
+        LOG.info(f" compare meta port {meta_port}")
+        LOG.info(f"compare: {meta_port.id} {meta_port.real_id} {meta_port.unique_id}")
+        LOG.info(f" {nsxt_agent_port.get('id')} {expected_id} {nsxt_agent_port.get('vif_details').get('segmentation_id')}")
+
+        self.assertEquals(meta_port.id, expected_id)
+        self.assertEquals(meta_port.real_id, vspbere_port[0].get("id"))
+        self.assertEquals(meta_port.unique_id, expected_id)
+
+        provider_port_results = requests.get(get_url(
+            f"{provider_nsx_policy.API.SEARCH_QUERY}?query={provider_nsx_policy.API.SEARCH_Q_SEG_PORT.format(nsxt_agent_port.get('id'))}")).json()
+        self.assertEquals(1, len(provider_port_results.get("results", [])))
+        provider_port = provider_port_results.get("results")[0]
+
+        self.assertListEqual(provider_port.get("address_bindings"), nsxt_agent_port.get("address_bindings"))
+        self.assertEqual(provider_port.get("attachment").get("type"), "PARENT")
+        self.assertEqual(provider_port.get("attachment").get("traffic_tag"),
+                         nsxt_agent_port.get("vif_details").get("segmentation_id"))
+
+        self.assertListEqual(nsxt_agent_port.get("security_groups"),
+                             self.get_all_tags_from_scope(provider_port, "security_group"))


### PR DESCRIPTION
Fix duplicate segment port creation due to Nova/vSphere/NSX-T race
    
A race condition between Nova, vSphere, and the NSX-T agent can result in
vSphere preemptively creating a segment port before the NSX-T agent does.
These pre-created ports lack security group tags, yet share the same
attachment ID as NSX-T agent managed ports, leading to duplication issues.
    
Key differences in vSphere-created ports:
  - Created by user "system"
  - ID starts with "default:<random_uuid>"
  - ID is not the OpenStack port id
  - Original name format: <random_uuid>vmx@<openstack-port-id>
    
During the NSX-T sync loop, once metadata is updated, we identify these
duplicate ports by matching the attachment ID (which is derived from the
OpenStack port ID). The NSX-T agent does not handle duplicates. So it is
unclear which segment port gets updates.
    
To resolve this:
Before creating a new segment port, check for existing ports with the
same attachment ID and reuse them if found.
