### PR TITLE
Fix duplicate segment port creation due to Nova/vSphere/NSX-T race

### DIFF
--- a/networking_nsxv3/api/rpc.py
+++ b/networking_nsxv3/api/rpc.py
@@ -121,6 +121,12 @@ class NSXv3AgentRpcClient(object):
         else:
             LOG.debug("NSXv3AgentRpcClient: (no rpc call triggered): pass security_group_id or port_id as tupe ")
 
+    def is_port_realized(self, host, id):
+        """Get the realization status of a resource."""
+        LOG.debug("NSXv3AgentRpcClient: (is_port_realized): %s", id)
+        return self._get_call_context(host).call(
+            self.context, 'is_port_realized', port_id=id)
+
     def update_address_group(self, plugin: Ml2Plugin, payload: events.DBEventPayload):
         address_group = payload.states[1]
         self._get_call_context().cast(self.context, 'address_group_updated', address_group=address_group)

--- a/networking_nsxv3/api/rpc.py
+++ b/networking_nsxv3/api/rpc.py
@@ -1,4 +1,6 @@
 import oslo_messaging
+import neutron.notifiers.nova as nova_notifier
+
 from networking_nsxv3.common import constants as nsxv3_constants
 from networking_nsxv3.db import db
 from neutron_lib import context as neutron_context
@@ -238,6 +240,11 @@ class NSXv3ServerRpcApi(object):
         return cctxt.call(self.context, 'get_address_group_revision_number',
                           address_group_id=address_group_id)
 
+    @log_helpers.log_method_call
+    def send_nova_event(self, event):
+        cctxt = self.client.prepare()
+        return cctxt.call(self.context, 'send_nova_event', event=event)
+
 
 class NSXv3ServerRpcCallback(object):
     """Plugin-side RPC (implementation) for agent-to-plugin interaction.
@@ -362,3 +369,14 @@ class NSXv3ServerRpcCallback(object):
     @log_helpers.log_method_call
     def has_security_group_logging(self, context, security_group_id):
         return db.has_security_group_logging(context, security_group_id)
+
+    @log_helpers.log_method_call
+    def send_nova_event(self, context, event):
+        """Send a custom event to nova."""
+        notifier = nova_notifier.Notifier.get_instance()
+        if not notifier:
+            LOG.error("Nova notifier is not available.")
+            return
+        LOG.info("Sent custom Nova event: %s", event)
+        notifier.send_custom_port_status(event)
+        return

--- a/networking_nsxv3/extensions/nsxtpolicy.py
+++ b/networking_nsxv3/extensions/nsxtpolicy.py
@@ -1,0 +1,125 @@
+import abc
+import json
+import importlib
+import functools
+
+#Load common config here, as registering the api extension fails without
+from neutron.common import config
+config.register_common_config_options()
+
+from neutron.api import extensions
+from neutron.api.v2.resource import Resource
+from neutron_lib.api import extensions as api_extensions
+
+from neutron_lib.api import faults
+from neutron import policy
+
+try:
+    from neutron.api import wsgi
+except ImportError:
+    from neutron import wsgi
+
+from webob import exc as web_exc
+from webob import exc as exceptions
+from oslo_log import log
+
+import networking_nsxv3.extensions
+
+LOG = log.getLogger(__name__)
+
+ACCESS_RULE = "context_is_cloud_admin"
+
+def check_cloud_admin(f):
+    @functools.wraps(f)
+    def wrapper(self, request, *args, **kwargs):
+        if not policy.check(request.context, ACCESS_RULE, {'project_id': request.context.project_id}):
+            raise web_exc.HTTPUnauthorized("{} required for access".format(ACCESS_RULE))
+        return f(self, request, *args, **kwargs)
+    return wrapper
+
+class NSXTAPIDefinition:
+    NAME = "NSXT Policy API"
+    ALIAS = "nsxt-policy"
+    DESCRIPTION = "Expose NSXT Policy API via Neutron API"
+    UPDATED_TIMESTAMP = "2025-07-25T09:25:00+02:00"
+    RESOURCE_ATTRIBUTE_MAP = {}
+    SUB_RESOURCE_ATTRIBUTE_MAP = {}
+    REQUIRED_EXTENSIONS = []
+    OPTIONAL_EXTENSIONS = []
+
+
+class Nsxtpolicy(api_extensions.APIExtensionDescriptor):
+    """NSX policy API extensions"""
+    # class name cannot be camelcase, needs to be just capitalized
+
+    api_definition = NSXTAPIDefinition
+
+    @classmethod
+    def _add_controller(cls, endpoints, ctrl, path, parent=None, path_prefix=None):
+        member_actions = getattr(ctrl, "MEMBER_ACTIONS", None)
+        collection_actions = getattr(ctrl, "COLLECTION_ACTIONS", None)
+        res = Resource(ctrl, faults.FAULT_MAP)
+        ep = extensions.ResourceExtension(path, res,
+                                          member_actions=member_actions,
+                                          collection_actions=collection_actions,
+                                          parent=parent,
+                                          path_prefix=path_prefix)
+        endpoints.append(ep)
+
+    @classmethod
+    def get_resources(cls):
+        """List of extensions.ResourceExtension extension objects.
+
+        Resources define new nouns, and are accessible through URLs.
+        """
+        endpoints = []
+
+        driver_module = importlib.import_module('networking_nsxv3.plugins.ml2.drivers.nsxv3.driver')
+        driver = driver_module.VMwareNSXv3MechanismDriver()
+        cls._add_controller(endpoints, SegmentPortController(driver), "port", path_prefix='nsxt-policy')
+
+        return endpoints
+
+
+# make sure this plugin gets autodiscovered and disable api-support checks
+# we need to do it this way because we do not have our own plugin that we associate with
+extensions.register_custom_supported_check(Nsxtpolicy.get_alias(), lambda: True, True)
+extensions.append_api_extensions_path(networking_nsxv3.extensions.__path__)
+
+class SegmentPortController(wsgi.Controller):
+    MEMBER_ACTIONS = {"realization_status": 'GET'}
+
+    def __init__(self, driver):
+        self.driver = driver
+        super().__init__()
+
+    @check_cloud_admin
+    def index(self, request, **kwargs):
+        return {"extension_reached": True}
+
+    @check_cloud_admin
+    def show(self, request, **kwargs):
+        port_id = request.params.get("port_id")
+        binding_host = request.params.get('binding_host')
+
+        if port_id:
+            realization_status = self._port_realization_status(port_id, binding_host)
+        else:
+            raise web_exc.HTTPBadRequest("No port_id given")
+        return {"realized": realization_status}
+
+    @check_cloud_admin
+    def update(self, request, **kwargs):
+        raise web_exc.HTTPNotImplemented("Update operation is not supported")
+
+    @check_cloud_admin
+    def delete(self, request, **kwargs):
+        raise web_exc.HTTPNotImplemented("Delete operation is not supported")
+
+    def _port_realization_status(self, port_id, binding_host):
+        try:
+            status = self.driver.is_port_realized(port_id, binding_host)
+        except Exception as e:
+            LOG.error("Error getting realization status for port %s: %s", port_id, str(e))
+            return False
+        return status

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
@@ -135,9 +135,18 @@ class NSXv3AgentManagerRpcCallBackBase(amb.CommonAgentManagerRpcCallBackBase):
 
     def resource_update(self, context, log_obj):
         pass
-    
+
     def address_group_updated(self, context, address_group):
         self.callback(address_group, self.realizer.address_group_update)
+
+    def is_port_realized(self, context, port_id):
+        try:
+            realization_status = self.realizer.port_realization_status(port_id)
+        except Exception as e:
+            LOG.error("Failed to get port realization status: %s", e)
+            realization_status = False
+
+        return realization_status
 
 
 class NSXv3Manager(amb.CommonAgentManagerBase):

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
@@ -78,6 +78,8 @@ class NSXv3AgentManagerRpcCallBackBase(amb.CommonAgentManagerRpcCallBackBase):
             if bool(network_meta.get("nsx-logical-switch-id")):
                 self.realizer.precreate_port(current["id"], network_meta)
 
+        #During a live migration nova is called twice - precreate_unbound_port and precreate_port
+        self.realizer.notify_nova_about_port_realization_status(port_id=current["id"], segment_id=seg_id, server_id=current.get('device_id', ''))
         return network_meta
 
     def security_groups_member_updated(self, context, **kwargs):

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider.py
@@ -448,3 +448,12 @@ class Provider(abc.ABC):
         :port_ids: set - Port IDs
         :return: set - Port metadata
         """
+
+    @abc.abstractmethod
+    def notify_nova_after_port_realization(self, rpc, port_id, segmentation_id, server_id):
+        """
+        Notify Nova about port realization
+
+        :port_id: str - Port ID
+        :segmentation_id: int - Segmentation
+        """

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/provider_nsx_policy.py
@@ -713,13 +713,15 @@ class Provider(base.Provider):
         return False
 
     @exporter.IN_REALIZATION.track_inprogress()
-    def _wait_to_realize(self, resource_type, os_id):
+    def _wait_to_realize(self, resource_type, os_id, wait_for_segment_port=False, **kwargs):
         if resource_type == Provider.SG_RULES:
             path = API.POLICY.format(os_id)
         elif resource_type == Provider.SG_MEMBERS:
             path = API.GROUP.format(os_id)
         elif resource_type == Provider.ADDR_GROUPS:
             path = API.GROUP.format(os_id)
+        elif resource_type == Provider.PORT and wait_for_segment_port:
+            path = API.SEGMENT_PORT.format(kwargs.get("segmentation_id", "empty"), os_id)
         else:
             return
 
@@ -966,7 +968,21 @@ class Provider(base.Provider):
             LOG.info("Port: %s has %s security groups which is more than the maximum allowed %s. \
                 The port will be added to the security groups as a static member.", port_id, len(port_sgs), max_sg_tags)
             os_port["security_groups"] = None
+
         return self._realize(Provider.PORT, False, self.payload.segment_port, os_port, provider_port)
+
+    def notify_nova_after_port_realization(self, rpc, port_id, segmentation_id, server_id):
+        segmentation_id = "{}-{}".format(self.zone_name, segmentation_id)
+        self._wait_to_realize(resource_type=Provider.PORT, os_id=port_id, wait_for_segment_port=True, segmentation_id=segmentation_id)
+        event = (
+            {'name': "network-port-realization-done",
+             'status': 'completed',
+             'tag': port_id,
+            'server_uuid': server_id}
+        )
+        LOG.info("Notify nova about port status change for port %s - send %s", port_id, event)
+        rpc.send_nova_event(event)
+
     def get_port(self, os_id):
         port = self.client.get_unique(path=API.SEARCH_QUERY, params={"query": API.SEARCH_Q_SEG_PORT.format(os_id)})
         if port:

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
@@ -5,6 +5,7 @@ from oslo_log import log as logging
 from oslo_config import cfg
 from networking_nsxv3.api.rpc import NSXv3ServerRpcApi
 from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import provider
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.provider_nsx_policy import API
 from networking_nsxv3.common.locking import LockManager
 from typing import Callable, List, Set, Tuple
 import itertools
@@ -283,6 +284,11 @@ class AgentRealizer(object):
             else:
                 LOG.info("deletion realization of port %s", os_id)
                 self._port_realize({"id": os_id}, delete=True)
+
+    def notify_nova_about_port_realization_status(self, port_id, segment_id, server_id):
+        LOG.info("Segment Port %s created on segment %s. Wait for realization and notify Nova", port_id, segment_id)
+        eventlet.spawn(self.nsx_provider.notify_nova_after_port_realization, self.rpc, port_id, segment_id, server_id)
+
 
     def qos(self, os_id: str, reference=False):
         """

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
@@ -285,6 +285,36 @@ class AgentRealizer(object):
                 LOG.info("deletion realization of port %s", os_id)
                 self._port_realize({"id": os_id}, delete=True)
 
+    def port_realization_status(self, port_id):
+        LOG.info("Fetching the port realization status for port_id: %s", port_id)
+
+        res = self.nsx_provider.client.get(path=API.SEARCH_QUERY, params={"query": API.SEARCH_Q_SEG_PORT.format(port_id)})
+        results = res.json()
+
+        segment_ports = None
+
+        if res.status_code >= 400:
+            LOG.error("Error fetching port realization status for port_id: %s", port_id)
+            return False
+
+        if results:
+            segment_ports = results.get("results")
+
+        if not segment_ports:
+            LOG.error("No segment port found for port_id: %s", port_id)
+            return False
+
+        if len(segment_ports) > 1:
+            LOG.error("Multiple segment port found for port_id: %s.", port_id)
+            return False
+
+        segment_port = segment_ports[0]
+        status = segment_port.get("status")
+        if status["publish_status"] == "REALIZED" and status["consolidated_status"]["consolidated_status"] == "SUCCESS":
+            return True
+        else:
+            return False
+
     def notify_nova_about_port_realization_status(self, port_id, segment_id, server_id):
         LOG.info("Segment Port %s created on segment %s. Wait for realization and notify Nova", port_id, segment_id)
         eventlet.spawn(self.nsx_provider.notify_nova_after_port_realization, self.rpc, port_id, segment_id, server_id)

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/driver.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/driver.py
@@ -1,3 +1,4 @@
+
 from neutron import service
 from neutron.agent import securitygroups_rpc
 from neutron.db import provisioning_blocks

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/driver.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/driver.py
@@ -8,6 +8,7 @@ from neutron_lib.services.trunk import constants as trunk_consts
 from neutron_lib import context as ctx, rpc
 from neutron_lib.api.definitions import portbindings
 from neutron_lib.callbacks import resources, registry, events
+from neutron_lib.plugins import directory
 from neutron_lib.plugins.ml2 import api
 from oslo_log import log
 
@@ -18,6 +19,7 @@ from networking_nsxv3.services.trunk.drivers.nsxv3 import trunk as nsxv3_trunk
 from networking_nsxv3.services.logapi.drivers.nsxv3 import driver as nsxv3_logging
 from neutron.objects import trunk as trunk_objects
 
+from networking_nsxv3.extensions.nsxtpolicy import Nsxtpolicy # auto-loads api on neutron server start
 from networking_nsxv3.extensions.nsxtoperations import Nsxtoperations  # auto-loads api on neutron server start
 
 from oslo_utils import importutils
@@ -81,12 +83,18 @@ class VMwareNSXv3MechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                 self.vif_type,
                 self.vif_details
         )
-
+        self._plugin = None
         LOG.info("Initialized Mechanism Driver Type = " + str(self.agent_type))
 
     @property
     def connectivity(self):
         return portbindings.CONNECTIVITY_L2
+
+    @property
+    def plugin(self):
+        if self._plugin is None:
+            self._plugin = directory.get_plugin()
+        return self._plugin
 
     def get_workers(self):
         return [service.RpcWorker([self], worker_process_count=0)]
@@ -245,3 +253,12 @@ class VMwareNSXv3MechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
 
     def trigger_sync(self, id, type):
         self.rpc.trigger_manual_update(id=id, type=type)
+
+    def is_port_realized(self, port_id, binding_host):
+        context = ctx.get_admin_context()
+
+        if not binding_host:
+            port = self.plugin.get_port(context, port_id)
+            binding_host = port.get(portbindings.HOST_ID)
+
+        return self.rpc.is_port_realized(binding_host, port_id)

--- a/networking_nsxv3/tests/unit/extensions/test_realizationstate.py
+++ b/networking_nsxv3/tests/unit/extensions/test_realizationstate.py
@@ -1,0 +1,58 @@
+import eventlet
+eventlet.monkey_patch()
+
+import json
+import webtest
+import networking_nsxv3.common.config
+
+from neutron.api import extensions
+from neutron.plugins.ml2 import models as ml2_models
+from neutron.tests.unit.api.test_extensions import setup_extensions_middleware
+from networking_nsxv3.api.rpc import NSXv3AgentRpcClient
+from networking_nsxv3.extensions import __path__ as nsxt_ext_path
+from networking_nsxv3.extensions import nsxtpolicy
+from neutron_lib.api.definitions import portbindings
+from unittest import mock
+
+
+from neutron.tests.unit.plugins.ml2 import test_plugin
+
+class TestCustomExtension(test_plugin.Ml2PluginV2TestCase):
+    def setUp(self):
+        super().setUp()
+        self.ext_mgr = extensions.ExtensionManager(nsxt_ext_path[0])
+        self.app = webtest.TestApp(setup_extensions_middleware(self.ext_mgr))
+
+    def test_extension_registration(self):
+        # Registration happens automatically when the driver is imported
+        ext_paths = extensions.get_extensions_path()
+        self.assertIn(nsxt_ext_path[0], ext_paths)
+
+    def test_extension_loaded(self):
+        assert nsxtpolicy.Nsxtpolicy.get_alias() in self.ext_mgr.extensions
+
+    def test_extension_status(self):
+        resp = self.app.get("/nsxt-policy/port")
+        self.assertEqual({'extension_reached': True}, resp.json)
+
+    def test_port_realization_status(self):
+        port_id = "fake-port-id"
+        binding_host = 'fake-host'
+
+        with mock.patch.object(NSXv3AgentRpcClient, 'is_port_realized', return_value=True):
+            resp = self.app.get(f"/nsxt-policy/port/realization_status?port_id={port_id}&binding_host={binding_host}")
+            self.assertEqual({'realized': True}, resp.json)
+
+    def test_port_realization_status_no_binding_host(self):
+        host = 'fake-host'
+        host_arg = {portbindings.HOST_ID: host}
+        with self.port(device_owner='compute:xyz', is_admin=True,
+                       arg_list=(portbindings.HOST_ID,),
+                       **host_arg) as port:
+            port_id = port["port"]['id']
+
+            from networking_nsxv3.api.rpc import NSXv3AgentRpcClient
+            with mock.patch.object(NSXv3AgentRpcClient, 'is_port_realized',
+                                   return_value=True) as mock_get_realization_status:
+                self.app.get(f"/nsxt-policy/port/realization_status?port_id={port_id}")
+                mock_get_realization_status.assert_called_once_with("fake-host", port_id)

--- a/networking_nsxv3/tests/unit/openstack.py
+++ b/networking_nsxv3/tests/unit/openstack.py
@@ -384,3 +384,6 @@ class TestNSXv3ServerRpcApi(object):
     def has_security_group_logging(self, security_group_id):
         g = self.inventory.get_by_id(NeutronMock.SECURITY_GROUP, security_group_id)
         return g is not None and g.get("logged")
+
+    def send_nova_event(self, event):
+        pass

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -34,3 +34,5 @@ pyopenssl
 python-memcached
 python-neutronclient
 python-novaclient
+WebTest>=2.0.27 # MIT
+responses


### PR DESCRIPTION
A race condition between Nova, vSphere, and the NSX-T agent can result in
vSphere preemptively creating a segment port before the NSX-T agent does.
These pre-created ports lack security group tags, yet share the same
attachment ID as NSX-T agent managed ports, leading to duplication issues.

Key differences in vSphere-created ports:
 - Created by user "system"
 - ID starts with "default:<random_uuid>"
 - ID is not the OpenStack port id
 - Original name format: <random_uuid>vmx@<openstack-port-id>

During the NSX-T sync loop, once metadata is updated, we identify these
duplicate ports by matching the attachment ID (which is derived from the
OpenStack port ID). The NSX-T agent does not handle duplicates. So it is
unclear which segment port gets updates.

To resolve this:
Send a custom notification that Nova is waiting for to continue the
server creation process. This ensures that the NSX-T agent creates the
segment port before Nova proceeds.