### PR TITLE
 Adjust sentry fingerprinting and Add metrics for API call durations and errors

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
@@ -44,12 +44,13 @@ class Singleton(type):
 
 class RetryPolicy(object):
 
-    def _create_sentry_fingerprint(path: str):
-        # check if uuid is part of path -> replace with {}
+    @staticmethod
+    def _create_sentry_fingerprint(path: str, placeholder: str = "{}") -> str:
+        # check if uuid is part of path -> replace with placeholder
         for sub in path.split("/"):
             try:
                 uuid.UUID(sub)
-                path.replace(sub, "{}")
+                path = path.replace(sub, placeholder)
             except ValueError:
                 pass
         return path
@@ -121,6 +122,9 @@ class RetryPolicy(object):
                 LOG.debug(msg)
                 eventlet.sleep(pause)
 
+            m = response.request.method if response else "UNKNOWN"
+            sentry_extra["fingerprint"] = [RetryPolicy._create_sentry_fingerprint(kwargs.get("path", '')), m]
+            LOG.exception(last_err, extra=sentry_extra)
             raise RuntimeError(msg, last_err)
 
         return decorator

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
@@ -3,7 +3,7 @@ import eventlet
 eventlet.monkey_patch()
 
 from requests import Response
-from requests.exceptions import ConnectionError, ConnectTimeout, HTTPError
+from requests.exceptions import ConnectionError, ConnectTimeout, HTTPError, ReadTimeout
 from oslo_utils import versionutils
 from oslo_log import log as logging
 from oslo_config import cfg
@@ -151,7 +151,7 @@ class RetryPolicy(object):
                                                        response.request.method]
                         LOG.error("Request=%s Response=%s", request_info, last_err, extra=sentry_extra)
                         break
-                except (HTTPError, ConnectionError, ConnectTimeout) as err:
+                except (HTTPError, ConnectionError, ConnectTimeout, ReadTimeout) as err:
                     last_err = err
                     m = response.request.method if response else "UNKNOWN"
                     sentry_extra["fingerprint"] = [RetryPolicy._create_sentry_fingerprint(kwargs.get("path", '')), m]

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
@@ -1,4 +1,5 @@
 import eventlet
+
 eventlet.monkey_patch()
 
 from requests import Response
@@ -8,6 +9,7 @@ from oslo_log import log as logging
 from oslo_config import cfg
 from networking_nsxv3.common.synchronization import Scheduler
 from networking_nsxv3.common.locking import LockManager
+from networking_nsxv3.prometheus import exporter
 import requests
 import uuid
 import time
@@ -43,9 +45,26 @@ class Singleton(type):
 
 
 class RetryPolicy(object):
+    BASE = "/policy/api/v1"
+    BASE_INFRA = f"{BASE}/infra"
+    RULES = [
+        # Regex Order matters
+        # Match security_rule before security_policy
+        # Match ports before segments
+        ('security_rule', re.compile(f"^{BASE_INFRA}/domains/default/security-policies/.*/rules.*")),
+        ('security_policy', re.compile(f"^{BASE_INFRA}/domains/default/security-policies.*")),
+        ('group', re.compile(f"^{BASE_INFRA}/domains/default/groups.*")),
+        ('port', re.compile(f"^{BASE_INFRA}/segments/.*/ports.*")),
+        ('segments', re.compile(f"^{BASE_INFRA}/segments.*")),
+        ('realized_state', re.compile(f'^{BASE_INFRA}/realized-state/status.*')),
+        ('services', re.compile(f"^{BASE_INFRA}/services.*")),
+        ('search', re.compile(f"^{BASE}/search.*")),
+        ('transport_zone', re.compile(f"^{BASE_INFRA}/sites/default/enforcement-points/default/transport-zones.*")),
+        ('qos_profile', re.compile(f"^{BASE_INFRA}/default/qos-profiles.*")),
+    ]
 
-    @staticmethod
-    def _create_sentry_fingerprint(path: str, placeholder: str = "{}") -> str:
+    @classmethod
+    def _create_sentry_fingerprint(cls, path: str, placeholder: str = "{}") -> str:
         # check if uuid is part of path -> replace with placeholder
         for sub in path.split("/"):
             try:
@@ -54,6 +73,25 @@ class RetryPolicy(object):
             except ValueError:
                 pass
         return path
+
+    @classmethod
+    def _get_resource_type(cls, path: str) -> str:
+        for name, rule in cls.RULES:
+            match = rule.match(path)
+            if match:
+                return name
+        return "unknown"
+
+    @classmethod
+    def _update_metric(cls, metric, path='', status='UNKNOWN', method='UNKNOWN', response_time=0, exception_type='UNKNOWN'):
+        fp_path = cls._create_sentry_fingerprint(path=path, placeholder="<uuid>")
+        resource = cls._get_resource_type(path)
+
+        if exporter.API_CALLS == metric:
+            metric.labels(method=method, bb=cfg.CONF.host, resource_type=resource, path=fp_path, status=status).observe(response_time)
+
+        if exporter.API_CALL_EXCEPTIONS == metric:
+            metric.labels(bb=cfg.CONF.host, resource=resource, path=path, exception_type=exception_type).inc()
 
     def __call__(self, func):
 
@@ -77,7 +115,9 @@ class RetryPolicy(object):
                 try:
                     response = func(self, *args, **kwargs)
                     # LOG.debug("REQUEST: %s STATUS: %s, RESPONSE.CONTENT %s", requestInfo, response.status_code, response.content)
-
+                    RetryPolicy._update_metric(exporter.API_CALLS, path=kwargs.get("path", ''), method=response.request.method,
+                                               status=response.status_code,
+                                               response_time=response.elapsed.total_seconds())
                     if response.status_code in [404]:
                         LOG.warning("Warning Code=%s Message=%s", response.status_code, response.content)
                         return response
@@ -115,6 +155,8 @@ class RetryPolicy(object):
                     last_err = err
                     m = response.request.method if response else "UNKNOWN"
                     sentry_extra["fingerprint"] = [RetryPolicy._create_sentry_fingerprint(kwargs.get("path", '')), m]
+                    RetryPolicy._update_metric(exporter.API_CALL_EXCEPTIONS, path=kwargs.get("path", ''),
+                                               exception_type=type(err).__name__)
                     LOG.error("Request=%s Response=%s", request_info, last_err, extra=sentry_extra)
 
                 msg = pattern.format(attempt, until, pause, method)

--- a/networking_nsxv3/prometheus/exporter.py
+++ b/networking_nsxv3/prometheus/exporter.py
@@ -6,7 +6,7 @@ from eventlet.green.http.server import HTTPServer
 import threading
 
 from oslo_config import cfg
-from prometheus_client import CollectorRegistry, Gauge, MetricsHandler, Counter, Enum
+from prometheus_client import CollectorRegistry, Gauge, MetricsHandler, Counter, Histogram
 
 # Prometheus Metrics
 
@@ -39,6 +39,18 @@ REALIZED = Counter(
     registry=REGISTRY
 )
 
+API_CALLS = Histogram(
+    'nsxv3_agent_api_calls',
+    'API call duration made by the agent',
+    ['bb', 'resource_type','method', 'path', 'status'],
+    registry=REGISTRY)
+
+API_CALL_EXCEPTIONS = Counter(
+    'nsxv3_agent_api_call_exceptions',
+    'API call exceptions made by the agent',
+    ['bb', 'resource_type', "exception_type"],
+    registry=REGISTRY
+)
 
 def nsxv3_agent_exporter():
     os.environ['PATH_INFO'] = "/metrics"

--- a/networking_nsxv3/tests/unit/test_retry_policy.py
+++ b/networking_nsxv3/tests/unit/test_retry_policy.py
@@ -1,0 +1,22 @@
+import unittest
+import uuid
+
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.client_nsx import RetryPolicy
+
+class TestRetryPolicyHelper(unittest.TestCase):
+
+    def test_get_resource_type(self):
+        os_id = uuid.uuid4()
+        paths = [
+            ('security_rule', f"/policy/api/v1/infra/domains/default/security-policies/{os_id}/rules"),
+            ('security_rule', f"/policy/api/v1/infra/domains/default/security-policies/{os_id}/rules/{os_id}"),
+            ('security_policy', f"/policy/api/v1/infra/domains/default/security-policies"),
+            ('security_policy', f"/policy/api/v1/infra/domains/default/security-policies/{os_id}"),
+            ('group', f"/policy/api/v1/infra/domains/default/groups/{os_id}"),
+            ('port', f"/policy/api/v1/infra/segments/{os_id}/ports"),
+            ('segments', f"/policy/api/v1/infra/segments/{os_id}")
+        ]
+
+        for resource_type, path in paths:
+            classified = RetryPolicy._get_resource_type(path)
+            self.assertEqual(resource_type, classified)


### PR DESCRIPTION
 Adjust fingerprinting to reduce event noise for NSX-T API calls
    
Sentry groups events by fingerprint. This change customizes the fingerprinting
for NSX-T-related errors to avoid generating separate events for each API call
with a unique ID. The replace operation does not work in-place, so the adjustment
ensures consistent grouping.

-----

Add metrics for API call durations and errors
    
This commit introduces Prometheus metrics to capture details about outgoing
API calls, including their duration and status codes. Additionally, a separate
to track request-level errors such as connection timeouts and network failures.
These metrics provide better observability into API behavior and help identify
performance or reliability issues.

