### PR TITLE
 Fix ValueError('Incorrect label names')

### DIFF
--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/client_nsx.py
@@ -91,7 +91,7 @@ class RetryPolicy(object):
             metric.labels(method=method, bb=cfg.CONF.host, resource_type=resource, path=fp_path, status=status).observe(response_time)
 
         if exporter.API_CALL_EXCEPTIONS == metric:
-            metric.labels(bb=cfg.CONF.host, resource=resource, path=path, exception_type=exception_type).inc()
+            metric.labels(bb=cfg.CONF.host, resource_type=resource, path=path, exception_type=exception_type).inc()
 
     def __call__(self, func):
 


### PR DESCRIPTION
When request errors occur (e.g. ConnectTimeout),
the `path` label was not added to the Prometheus metric, causing a ValueError.