### PR TITLE
Add security_group_sync_mode configuration option

### DIFF
--- a/networking_nsxv3/common/config.py
+++ b/networking_nsxv3/common/config.py
@@ -91,6 +91,22 @@ agent_opts = [
         name='resync_objects_based_on_age',
         default=True,
         help="Enable/Disable the resync of aged objects in a sync loop"
+    ),
+    cfg.StrOpt(
+        name='security_group_sync_mode',
+        default='active',
+        choices=['active', 'passive'],
+        help="Security group synchronization mode. 'active': agent creates and updates security "
+             "groups in NSX-T. 'passive': agent waits for security groups to exist but does not "
+             "create or update them (useful in multi-agent deployments where one agent manages "
+             "security groups centrally)."
+    ),
+    cfg.IntOpt(
+        name='security_group_wait_timeout',
+        default=30,
+        help="Maximum time in seconds to wait for security group objects to exist in NSX-T when "
+             "security_group_sync_mode is 'passive'. The agent will raise an exception if the "
+             "timeout is exceeded."
     )
 ]
 

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/agent.py
@@ -83,9 +83,15 @@ class NSXv3AgentManagerRpcCallBackBase(amb.CommonAgentManagerRpcCallBackBase):
         return network_meta
 
     def security_groups_member_updated(self, context, **kwargs):
+        if cfg.CONF.AGENT.security_group_sync_mode == 'passive':
+            LOG.debug("Security group member updates are disabled (passive mode)")
+            return
         self.callback(kwargs["security_groups"], self.realizer.security_group_members)
 
     def security_groups_rule_updated(self, context, **kwargs):
+        if cfg.CONF.AGENT.security_group_sync_mode == 'passive':
+            LOG.debug("Security group rule updates are disabled (passive mode)")
+            return
         self.callback(kwargs["security_groups"], self.realizer.security_group_rules)
 
     def port_create(self, **kwargs):

--- a/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
+++ b/networking_nsxv3/plugins/ml2/drivers/nsxv3/agent/realization.py
@@ -102,20 +102,23 @@ class AgentRealizer(object):
             if _slice <= 0:
                 return
 
-            outdated = list(itertools.islice(sgr_outdated, _slice))
-            _slice -= len(outdated)
-            LOG.info("Realizing %s/%s resources of Type:Security Group Rules", len(outdated), len(sgr_outdated))
-            self.callback(outdated, self.security_group_rules)
-            if _slice <= 0:
-                return
+            if cfg.CONF.AGENT.security_group_sync_mode == 'passive':
+                LOG.debug("Security group synchronization is disabled (passive mode)")
+            else:
+                outdated = list(itertools.islice(sgr_outdated, _slice))
+                _slice -= len(outdated)
+                LOG.info("Realizing %s/%s resources of Type:Security Group Rules", len(outdated), len(sgr_outdated))
+                self.callback(outdated, self.security_group_rules)
+                if _slice <= 0:
+                    return
 
-            # sgm_outdated only includes missing objects, orphans are removed by ageing
-            outdated = list(itertools.islice(sgm_outdated, _slice))
-            _slice -= len(outdated)
-            LOG.info("Realizing %s/%s resources of Type:Security Group Members", len(outdated), len(sgm_outdated))
-            self.callback(outdated, self.security_group_members)
-            if _slice <= 0:
-                return
+                # sgm_outdated only includes missing objects, orphans are removed by ageing
+                outdated = list(itertools.islice(sgm_outdated, _slice))
+                _slice -= len(outdated)
+                LOG.info("Realizing %s/%s resources of Type:Security Group Members", len(outdated), len(sgm_outdated))
+                self.callback(outdated, self.security_group_members)
+                if _slice <= 0:
+                    return
 
             outdated = list(itertools.islice(qos_outdated, _slice))
             _slice -= len(outdated)
@@ -165,6 +168,35 @@ class AgentRealizer(object):
 
             self.AGE = int(time.time())
 
+    def _wait_for_security_group(self, os_id: str, timeout: int = None):
+        """
+        Wait for a security group to exist in NSX-T (created by another agent).
+        :os_id: -- OpenStack ID of the Security Group
+        :timeout: -- Maximum time in seconds to wait (uses config default if None)
+        :raises: TimeoutError if the security group doesn't exist after timeout
+        """
+        if timeout is None:
+            timeout = cfg.CONF.AGENT.security_group_wait_timeout
+        
+        start_time = time.time()
+        poll_interval = 1  # Poll every second
+        
+        while time.time() - start_time < timeout:
+            # Check if the SG rules exist in NSX-T
+            meta = self.nsx_provider.metadata(self.nsx_provider.SG_RULES, os_id)
+            if meta:
+                LOG.debug(f"Security group {os_id} found in NSX-T")
+                return
+            
+            LOG.debug(f"Waiting for security group {os_id} to exist in NSX-T... "
+                     f"({int(time.time() - start_time)}s / {timeout}s)")
+            time.sleep(poll_interval)
+        
+        raise TimeoutError(
+            f"Security group {os_id} does not exist in NSX-T after {timeout}s timeout. "
+            f"Ensure another agent is managing security groups."
+        )
+
     def security_group_members(self, os_id: str, reference=False):
         """
         Realize security group members state.
@@ -173,6 +205,11 @@ class AgentRealizer(object):
         :os_id: -- OpenStack ID of the Security Group
         :reference: -- if True will create the group if unknown by the provider
         """
+        if cfg.CONF.AGENT.security_group_sync_mode == 'passive':
+            LOG.debug(f"Security group members in passive mode, waiting for {os_id} to exist")
+            self._wait_for_security_group(os_id)
+            return
+        
         with LockManager.get_lock("member-{}".format(os_id)):
             meta = self.nsx_provider.metadata(self.nsx_provider.SG_MEMBERS, os_id)
             if not (reference and meta):
@@ -199,6 +236,11 @@ class AgentRealizer(object):
         Realization will happen only if the group has active ports on the host.
         :os_id: -- OpenStack ID of the Security Group
         """
+        if cfg.CONF.AGENT.security_group_sync_mode == 'passive':
+            LOG.debug(f"Security group rules in passive mode, waiting for {os_id} to exist")
+            self._wait_for_security_group(os_id)
+            return
+        
         with LockManager.get_lock("rules-{}".format(os_id)):
             os_sg = self.rpc.get_security_group(os_id)
 

--- a/networking_nsxv3/tests/unit/test_disable_security_groups.py
+++ b/networking_nsxv3/tests/unit/test_disable_security_groups.py
@@ -1,0 +1,91 @@
+from unittest import mock
+
+from neutron.tests import base
+from oslo_config import cfg
+
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import agent
+from networking_nsxv3.plugins.ml2.drivers.nsxv3.agent import realization
+from networking_nsxv3.tests.unit import provider
+
+
+class TestDisableSecurityGroupUpdates(base.BaseTestCase):
+    """Test cases for security_group_sync_mode configuration option."""
+
+    def setUp(self):
+        super(TestDisableSecurityGroupUpdates, self).setUp()
+        cfg.CONF.set_override('security_group_sync_mode', 'active', group='AGENT')
+        cfg.CONF.set_override('security_group_wait_timeout', 30, group='AGENT')
+        
+        self.context = mock.Mock()
+        self.mock_agent = mock.Mock()
+        self.mock_sg_agent = mock.Mock()
+        self.mock_realizer = mock.Mock(spec=realization.AgentRealizer)
+        self.mock_callback = mock.Mock()
+
+        self.rpc_callback = agent.NSXv3AgentManagerRpcCallBackBase(
+            self.context,
+            self.mock_agent,
+            self.mock_sg_agent,
+            self.mock_callback,
+            self.mock_realizer
+        )
+
+    def tearDown(self):
+        super(TestDisableSecurityGroupUpdates, self).tearDown()
+        cfg.CONF.clear_override('security_group_sync_mode', group='AGENT')
+        cfg.CONF.clear_override('security_group_wait_timeout', group='AGENT')
+
+    def test_security_groups_member_updated_enabled(self):
+        """Test that security group member updates are processed in active mode."""
+        cfg.CONF.set_override('security_group_sync_mode', 'active', group='AGENT')
+        
+        security_groups = ['sg-1', 'sg-2']
+        self.rpc_callback.security_groups_member_updated(
+            self.context,
+            security_groups=security_groups
+        )
+        
+        self.mock_callback.assert_called_once_with(
+            security_groups,
+            self.mock_realizer.security_group_members
+        )
+
+    def test_security_groups_member_updated_disabled(self):
+        """Test that security group member updates are skipped in passive mode."""
+        cfg.CONF.set_override('security_group_sync_mode', 'passive', group='AGENT')
+        
+        security_groups = ['sg-1', 'sg-2']
+        self.rpc_callback.security_groups_member_updated(
+            self.context,
+            security_groups=security_groups
+        )
+        
+        self.mock_callback.assert_not_called()
+
+    def test_security_groups_rule_updated_enabled(self):
+        """Test that security group rule updates are processed in active mode."""
+        cfg.CONF.set_override('security_group_sync_mode', 'active', group='AGENT')
+        
+        security_groups = ['sg-1', 'sg-2']
+        self.rpc_callback.security_groups_rule_updated(
+            self.context,
+            security_groups=security_groups
+        )
+        
+        self.mock_callback.assert_called_once_with(
+            security_groups,
+            self.mock_realizer.security_group_rules
+        )
+
+    def test_security_groups_rule_updated_disabled(self):
+        """Test that security group rule updates are skipped in passive mode."""
+        cfg.CONF.set_override('security_group_sync_mode', 'passive', group='AGENT')
+        
+        security_groups = ['sg-1', 'sg-2']
+        self.rpc_callback.security_groups_rule_updated(
+            self.context,
+            security_groups=security_groups
+        )
+        
+        self.mock_callback.assert_not_called()
+


### PR DESCRIPTION
Introduces security_group_sync_mode with 'active'/'passive' modes for multi-agent deployments. In passive mode, agents wait for security groups to exist in NSX-T instead of creating/updating them.

Config: security_group_sync_mode (default: active)
Config: security_group_wait_timeout (default: 30 seconds)